### PR TITLE
feat: cricket manager fantasy format end-to-end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ build/
 .env.local
 .env.production
 .env.*.local
+.env.expo-prod
 
 # IDE
 .vscode/

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -3,6 +3,7 @@ import { StatusBar } from "expo-status-bar";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState, useEffect } from "react";
 import { ActivityIndicator, View, Platform } from "react-native";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
 // Sentry — no-op stub (install @sentry/react-native to enable)
 const Sentry = {
   init: (..._args: unknown[]) => {},
@@ -102,6 +103,10 @@ function InnerLayout() {
         <Stack.Screen name="league/[id]" />
         <Stack.Screen name="league/[id]/trades" />
         <Stack.Screen name="league/[id]/settings" />
+        <Stack.Screen name="league/[id]/round/[roundId]/index" />
+        <Stack.Screen name="league/[id]/round/[roundId]/build" />
+        <Stack.Screen name="league/[id]/round/[roundId]/leaderboard" />
+        <Stack.Screen name="league/[id]/round/[roundId]/reveal/[userId]" />
         <Stack.Screen name="draft/[id]" />
         <Stack.Screen name="auction/[id]" />
         <Stack.Screen name="subscription/index" />
@@ -181,19 +186,21 @@ function RootLayout() {
   }
 
   return (
-    <trpc.Provider client={trpcClient} queryClient={queryClient}>
-      <QueryClientProvider client={queryClient}>
-        <AuthProvider>
-          <NotificationProvider>
-            <ThemeProvider>
-              <WebLayoutWrapper>
-                <InnerLayout />
-              </WebLayoutWrapper>
-            </ThemeProvider>
-          </NotificationProvider>
-        </AuthProvider>
-      </QueryClientProvider>
-    </trpc.Provider>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <trpc.Provider client={trpcClient} queryClient={queryClient}>
+        <QueryClientProvider client={queryClient}>
+          <AuthProvider>
+            <NotificationProvider>
+              <ThemeProvider>
+                <WebLayoutWrapper>
+                  <InnerLayout />
+                </WebLayoutWrapper>
+              </ThemeProvider>
+            </NotificationProvider>
+          </AuthProvider>
+        </QueryClientProvider>
+      </trpc.Provider>
+    </GestureHandlerRootView>
   );
 }
 

--- a/apps/mobile/app/league/[id].tsx
+++ b/apps/mobile/app/league/[id].tsx
@@ -91,6 +91,11 @@ export default function LeagueDetailScreen() {
     </YStack>
   );
 
+  // Cricket Manager format has its own layout — rounds + season standings
+  if (league.format === "cricket_manager") {
+    return <CricketManagerLeagueView league={league} leagueId={id!} />;
+  }
+
   // Match by DB UUID or by email (user.id is Firebase UID, members use DB UUID)
   const myMembership = league.members?.find((m: any) =>
     m.userId === user?.id || m.user?.email === user?.email
@@ -507,6 +512,369 @@ export default function LeagueDetailScreen() {
           ]}
         />
       )}
+    </YStack>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cricket Manager league view — rounds list + season standings
+// ─────────────────────────────────────────────────────────────────────────────
+
+const CM_STATUS_VARIANT: Record<
+  string,
+  "default" | "live" | "role" | "warning" | "danger" | "success"
+> = {
+  upcoming: "role",
+  open: "success",
+  locked: "role",
+  live: "live",
+  settled: "default",
+  void: "danger",
+};
+
+function CricketManagerLeagueView({
+  league,
+  leagueId,
+}: {
+  league: any;
+  leagueId: string;
+}) {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const { user } = useAuth();
+  const [cmTab, setCmTab] = useState<"rounds" | "standings" | "members">("rounds");
+
+  const roundsQuery = trpc.cricketManager.getLeagueRounds.useQuery(
+    { leagueId },
+    { refetchInterval: 15000 }
+  );
+  const standingsQuery = trpc.cricketManager.getLeagueStandings.useQuery(
+    { leagueId, limit: 200, offset: 0 },
+    { enabled: cmTab === "standings", refetchInterval: 15000 }
+  );
+
+  const roundsData = roundsQuery.data ?? [];
+  const standingsData = standingsQuery.data ?? [];
+  const data =
+    cmTab === "rounds"
+      ? roundsData
+      : cmTab === "standings"
+      ? standingsData
+      : league.members ?? [];
+
+  return (
+    <YStack flex={1} backgroundColor="$background" testID="cm-league-detail">
+      <FlatList
+        data={data as any[]}
+        keyExtractor={(item: any) =>
+          item.id ?? item.userId ?? `${Math.random()}`
+        }
+        contentContainerStyle={{ padding: 16 }}
+        ListHeaderComponent={
+          <>
+            <XStack
+              justifyContent="space-between"
+              alignItems="center"
+              paddingTop={insets.top + 8}
+              paddingBottom="$3"
+              marginBottom="$3"
+            >
+              <XStack alignItems="center" gap="$3">
+                <SafeBackButton />
+              </XStack>
+              <HeaderControls />
+            </XStack>
+            <AnnouncementBanner marginHorizontal={0} />
+
+            {/* League header */}
+            <Card padding="$5" marginBottom="$4">
+              <Text
+                fontFamily="$mono"
+                fontWeight="500"
+                fontSize={17}
+                color="$color"
+                letterSpacing={-0.5}
+              >
+                {league.name}
+              </Text>
+              <XStack marginTop="$2" gap="$3" flexWrap="wrap">
+                <Badge variant="role" size="sm">
+                  cricket manager
+                </Badge>
+                <Text
+                  fontFamily="$mono"
+                  fontSize={12}
+                  color="$colorMuted"
+                  alignSelf="center"
+                >
+                  {league.members?.length ?? 0}/{league.maxMembers}{" "}
+                  {formatUIText("members")}
+                </Text>
+              </XStack>
+              <Text
+                fontFamily="$body"
+                fontSize={13}
+                color="$colorMuted"
+                marginTop="$2"
+              >
+                {league.tournament}
+              </Text>
+              {league.rules?.cricketManager?.prizePool > 0 && (
+                <Text
+                  fontFamily="$mono"
+                  fontSize={12}
+                  color="$colorCricket"
+                  marginTop="$1"
+                >
+                  prize pool: {league.rules.cricketManager.prizePool} PC
+                </Text>
+              )}
+            </Card>
+
+            {/* Tab switcher */}
+            <XStack
+              marginBottom="$3"
+              borderRadius="$3"
+              backgroundColor="$backgroundSurfaceAlt"
+              padding="$1"
+              gap="$1"
+            >
+              {([
+                { key: "rounds" as const, label: "rounds" },
+                { key: "standings" as const, label: "standings" },
+                { key: "members" as const, label: "members" },
+              ]).map((t) => (
+                <SegmentTab
+                  key={t.key}
+                  active={cmTab === t.key}
+                  onPress={() => setCmTab(t.key)}
+                >
+                  <Text
+                    fontFamily="$body"
+                    fontWeight="600"
+                    fontSize={13}
+                    color={cmTab === t.key ? "$color" : "$colorMuted"}
+                  >
+                    {formatUIText(t.label)}
+                  </Text>
+                </SegmentTab>
+              ))}
+            </XStack>
+          </>
+        }
+        renderItem={({ item, index }: { item: any; index: number }) => {
+          if (cmTab === "rounds") {
+            const round = item;
+            return (
+              <Animated.View
+                entering={FadeInDown.delay(index * 40).springify()}
+              >
+                <Card
+                  pressable
+                  marginBottom="$2"
+                  padding="$4"
+                  onPress={() =>
+                    router.push(
+                      `/league/${leagueId}/round/${round.id}` as never
+                    )
+                  }
+                  borderColor={
+                    round.status === "live" ? "$colorCricket" : "$borderColor"
+                  }
+                  borderWidth={round.status === "live" ? 2 : 1}
+                  testID={`cm-round-${round.id}`}
+                >
+                  <XStack justifyContent="space-between" alignItems="flex-start">
+                    <XStack alignItems="center" gap="$2" flex={1}>
+                      <Text
+                        fontFamily="$mono"
+                        fontWeight="700"
+                        fontSize={12}
+                        color="$accentBackground"
+                        backgroundColor="rgba(61,153,104,0.1)"
+                        paddingHorizontal="$2"
+                        paddingVertical={2}
+                        borderRadius="$2"
+                      >
+                        R{round.roundNumber}
+                      </Text>
+                      <Text
+                        fontFamily="$body"
+                        fontWeight="700"
+                        fontSize={14}
+                        color="$color"
+                        flex={1}
+                        numberOfLines={1}
+                      >
+                        {round.name}
+                      </Text>
+                    </XStack>
+                    <Badge
+                      variant={CM_STATUS_VARIANT[round.status] ?? "default"}
+                      size="sm"
+                    >
+                      {formatBadgeText(round.status)}
+                    </Badge>
+                  </XStack>
+                  <Text
+                    fontFamily="$body"
+                    fontSize={11}
+                    color="$colorMuted"
+                    marginTop="$2"
+                  >
+                    {round.matchesTotal} {formatUIText("matches")} ·{" "}
+                    {new Date(round.windowStart).toLocaleDateString("en-IN", {
+                      day: "numeric",
+                      month: "short",
+                    })}
+                    {" → "}
+                    {new Date(round.windowEnd).toLocaleDateString("en-IN", {
+                      day: "numeric",
+                      month: "short",
+                    })}
+                  </Text>
+                  {round.totalEntries > 0 && (
+                    <Text
+                      fontFamily="$mono"
+                      fontSize={11}
+                      color="$colorCricket"
+                      marginTop="$1"
+                    >
+                      {round.totalEntries} {formatUIText("entries")}
+                      {round.bestNrr != null &&
+                        ` · best NRR ${Number(round.bestNrr).toFixed(2)}`}
+                    </Text>
+                  )}
+                </Card>
+              </Animated.View>
+            );
+          }
+
+          if (cmTab === "standings") {
+            const s = item;
+            const isMe = s.userId === user?.id;
+            const label = s.email ? s.email.split("@")[0] : "player";
+            return (
+              <Animated.View
+                entering={FadeInDown.delay(index * 30).springify()}
+              >
+                <Card
+                  marginBottom="$2"
+                  padding="$3"
+                  borderColor={isMe ? "$accentBackground" : "$borderColor"}
+                  borderWidth={isMe ? 2 : 1}
+                >
+                  <XStack alignItems="center">
+                    <YStack width={32} alignItems="center">
+                      <Text
+                        fontFamily="$mono"
+                        fontWeight="800"
+                        fontSize={14}
+                        color={
+                          index === 0
+                            ? "$colorCricket"
+                            : index === 1
+                            ? "$colorSecondary"
+                            : "$color"
+                        }
+                      >
+                        #{s.rank ?? index + 1}
+                      </Text>
+                    </YStack>
+                    <XStack alignItems="center" gap="$2" flex={1} marginLeft="$2">
+                      <InitialsAvatar
+                        name={label}
+                        playerRole="BAT"
+                        ovr={0}
+                        size={32}
+                        hideBadge
+                      />
+                      <YStack flex={1}>
+                        <Text {...textStyles.playerName}>{label}</Text>
+                        {isMe && (
+                          <Badge
+                            variant="live"
+                            size="sm"
+                            alignSelf="flex-start"
+                          >
+                            {formatUIText("you")}
+                          </Badge>
+                        )}
+                      </YStack>
+                    </XStack>
+                    <YStack alignItems="flex-end">
+                      <Text
+                        fontFamily="$mono"
+                        fontWeight="700"
+                        fontSize={15}
+                        color="$accentBackground"
+                      >
+                        {Number(s.totalNrr).toFixed(2)}
+                      </Text>
+                      <Text fontFamily="$mono" fontSize={9} color="$colorMuted">
+                        {s.roundsPlayed}{" "}
+                        {formatUIText(
+                          s.roundsPlayed === 1 ? "round" : "rounds"
+                        )}
+                      </Text>
+                    </YStack>
+                  </XStack>
+                </Card>
+              </Animated.View>
+            );
+          }
+
+          // Members tab
+          const m = item;
+          return (
+            <Animated.View entering={FadeInDown.delay(index * 30).springify()}>
+              <Card marginBottom="$2" padding="$4">
+                <XStack alignItems="center" gap="$3">
+                  <InitialsAvatar
+                    name={m.user?.displayName ?? m.user?.username ?? "?"}
+                    playerRole="BAT"
+                    ovr={0}
+                    size={36}
+                    hideBadge
+                  />
+                  <YStack flex={1}>
+                    <Text {...textStyles.playerName}>
+                      {m.user?.displayName ??
+                        m.user?.username ??
+                        formatUIText("unknown")}
+                    </Text>
+                    <Badge
+                      variant="role"
+                      size="sm"
+                      alignSelf="flex-start"
+                      marginTop={2}
+                    >
+                      {formatBadgeText(m.role)}
+                    </Badge>
+                  </YStack>
+                </XStack>
+              </Card>
+            </Animated.View>
+          );
+        }}
+        ListEmptyComponent={
+          cmTab === "rounds" ? (
+            <Card padding="$5" alignItems="center">
+              <Text {...textStyles.hint}>
+                {formatUIText(
+                  "no rounds yet — check back when the admin composes the first round"
+                )}
+              </Text>
+            </Card>
+          ) : cmTab === "standings" ? (
+            <Card padding="$5" alignItems="center">
+              <Text {...textStyles.hint}>
+                {formatUIText("no standings yet — submit a round entry to appear")}
+              </Text>
+            </Card>
+          ) : null
+        }
+      />
     </YStack>
   );
 }

--- a/apps/mobile/app/league/[id]/round/[roundId]/build.tsx
+++ b/apps/mobile/app/league/[id]/round/[roundId]/build.tsx
@@ -1,0 +1,3336 @@
+import { SafeBackButton } from "../../../../../components/SafeBackButton";
+import { ScrollView, Alert, Pressable, TextInput, Modal } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useState, useMemo, useEffect } from "react";
+import Animated, { FadeInDown } from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { YStack, XStack, useTheme as useTamaguiTheme } from "tamagui";
+import { Text } from "../../../../../components/SportText";
+import {
+  Card,
+  Badge,
+  Button,
+  FilterPill,
+  InitialsAvatar,
+  EggLoadingSpinner,
+  AlertModal,
+  TierBadge,
+  Paywall,
+  textStyles,
+  formatUIText,
+  formatBadgeText,
+  DesignSystem,
+  DraftPlayLogo,
+} from "@draftplay/ui";
+import { trpc } from "../../../../../lib/trpc";
+import { HeaderControls } from "../../../../../components/HeaderControls";
+import { usePaywall } from "../../../../../hooks/usePaywall";
+
+type Step = "squad" | "batting" | "bowling" | "review";
+type RoleKey = "BAT" | "BOWL" | "AR" | "WK";
+
+type EligiblePlayer = {
+  playerId: string;
+  name: string;
+  team: string;
+  role: string;
+  photoUrl?: string | null;
+  nationality?: string | null;
+  battingStyle?: string;
+  bowlingStyle?: string;
+  recentSr?: number;
+  recentAvg?: number;
+  recentEcon?: number;
+  recentBowlSr?: number;
+  formNote?: string | null;
+  recentForm?: number | null;
+};
+
+const TEAM_SIZE = 11;
+
+// Mirrors salary_cap role tabs, but CM doesn't impose per-role max caps — only min bowlers.
+// "picked" is a special tab handled separately that shows only the selected squad.
+const ROLE_TABS: Array<{ key: string; label: string; match: (r: string) => boolean }> = [
+  { key: "picked", label: "picked", match: () => true },
+  { key: "all", label: "all", match: () => true },
+  { key: "wicket_keeper", label: "keeper", match: (r) => r === "wicket_keeper" },
+  { key: "batsman", label: "batter", match: (r) => r === "batsman" },
+  { key: "all_rounder", label: "all-rounder", match: (r) => r === "all_rounder" },
+  { key: "bowler", label: "bowler", match: (r) => r === "bowler" },
+];
+
+function roleToBadge(role: string): RoleKey {
+  if (role === "bowler") return "BOWL";
+  if (role === "all_rounder") return "AR";
+  if (role === "wicket_keeper") return "WK";
+  return "BAT";
+}
+
+function canBowl(role: string) {
+  return role === "bowler" || role === "all_rounder";
+}
+
+// Normalize "Right Handed Bat" → "RH bat", "Left Handed Bat" → "LH bat"
+function shortBatStyle(style?: string): string | null {
+  if (!style) return null;
+  const lower = style.toLowerCase();
+  if (lower.includes("left")) return "LH";
+  if (lower.includes("right")) return "RH";
+  return null;
+}
+
+// Normalize "Right-arm fast" → "RA pace", "Slow Left-arm orthodox" → "SLA"
+function shortBowlStyle(style?: string): string | null {
+  if (!style) return null;
+  const lower = style.toLowerCase();
+  if (lower.includes("offbreak")) return "OB";
+  if (lower.includes("legbreak") || lower.includes("leg-break")) return "LB";
+  if (lower.includes("orthodox")) return "SLA";
+  if (lower.includes("chinaman")) return "SLC";
+  if (lower.includes("fast") || lower.includes("medium")) {
+    return lower.includes("left") ? "LA pace" : "RA pace";
+  }
+  return null;
+}
+
+// "Royal Challengers Bengaluru" → "RCB", "India" → "IND", "Mumbai Indians" → "MI"
+function teamShortCode(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0]!.substring(0, 3).toUpperCase();
+  return parts
+    .map((p) => p[0] ?? "")
+    .join("")
+    .toUpperCase();
+}
+
+// Aggregated stats from playerMatchScores for the matches in this round.
+// We fetch these server-side and use them to rank by recent form.
+type Projection = {
+  projectedPoints: number;
+  captainRank: number;
+};
+
+export default function EntryBuilderScreen() {
+  const { id: leagueId, roundId } = useLocalSearchParams<{
+    id: string;
+    roundId: string;
+  }>();
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const theme = useTamaguiTheme();
+  const { canAccess, gateFeature, paywallProps } = usePaywall();
+
+  // ── Round data ────────────────────────────────────────────────────
+  const roundQuery = trpc.cricketManager.getRound.useQuery(
+    { roundId: roundId! },
+    { enabled: !!roundId }
+  );
+
+  const submit = trpc.cricketManager.submitEntry.useMutation({
+    onSuccess: () => {
+      setAlert({
+        title: "entry saved",
+        message:
+          "your squad is in. you can come back and update it anytime until the round locks.",
+        onConfirm: () => {
+          // Navigate explicitly to the round hub so the user can review the
+          // saved entry and re-enter the builder if needed. router.back() is
+          // unreliable on web when the entry screen was opened directly.
+          if (leagueId && roundId) {
+            router.replace(
+              `/league/${leagueId}/round/${roundId}` as never
+            );
+          }
+        },
+      });
+    },
+    onError: (err: { message?: string }) => {
+      Alert.alert("Error", err.message ?? "Failed to submit");
+    },
+  });
+
+  // ── Step + local state ────────────────────────────────────────────
+  const [step, setStep] = useState<Step>("squad");
+  const [selectedTab, setSelectedTab] = useState<string>("all");
+  const [sortBy, setSortBy] = useState<"form" | "projected">("form");
+  const [smartFilter, setSmartFilter] = useState<
+    "all" | "differentials" | "value" | "form"
+  >("all");
+  const [statsPlayerId, setStatsPlayerId] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [battingOrder, setBattingOrder] = useState<string[]>([]);
+  const [bowlingPriority, setBowlingPriority] = useState<string[]>([]);
+  const [toss, setToss] = useState<"bat_first" | "bowl_first">("bat_first");
+  const [showExplainer, setShowExplainer] = useState(false);
+  const [showGuru, setShowGuru] = useState(false);
+
+  // Show NRR explainer once on first visit
+  useEffect(() => {
+    AsyncStorage.getItem("cm_explainer_seen").then((v) => {
+      if (!v) setShowExplainer(true);
+    });
+  }, []);
+
+  function dismissExplainer() {
+    setShowExplainer(false);
+    AsyncStorage.setItem("cm_explainer_seen", "1").catch(() => {});
+  }
+
+  const [alert, setAlert] = useState<{
+    title: string;
+    message: string;
+    onConfirm?: () => void;
+  } | null>(null);
+
+  // Hydrate from existing entry (if any)
+  useEffect(() => {
+    const entry = roundQuery.data?.myEntry;
+    if (entry && selectedIds.length === 0) {
+      const ids = (entry.players as Array<{ playerId: string }>).map(
+        (p) => p.playerId
+      );
+      setSelectedIds(ids);
+      const ordered = [
+        ...(entry.battingOrder as Array<{ position: number; playerId: string }>),
+      ]
+        .sort((a, b) => a.position - b.position)
+        .map((b) => b.playerId);
+      setBattingOrder(ordered);
+      const priority = [
+        ...(entry.bowlingPriority as Array<{
+          priority: number;
+          playerId: string;
+        }>),
+      ]
+        .sort((a, b) => a.priority - b.priority)
+        .map((b) => b.playerId);
+      setBowlingPriority(priority);
+      const savedToss = (entry as { toss?: string }).toss;
+      if (savedToss === "bat_first" || savedToss === "bowl_first") {
+        setToss(savedToss);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [roundQuery.data?.myEntry]);
+
+  // ── Derive first match — used as AI context for projections, XI, pitch ──
+  const round = roundQuery.data;
+  const eligible: EligiblePlayer[] = (round?.eligiblePlayers ?? []) as EligiblePlayer[];
+  const byId = useMemo(() => new Map(eligible.map((p) => [p.playerId, p])), [eligible]);
+
+  const firstMatch = useMemo(() => {
+    const matches = (round?.matches ?? []) as Array<{
+      id: string;
+      teamHome: string;
+      teamAway: string;
+      venue: string | null;
+      tournament: string;
+      format: string;
+      startTime: string | Date;
+    }>;
+    if (matches.length === 0) return null;
+    return [...matches].sort(
+      (a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
+    )[0]!;
+  }, [round?.matches]);
+
+  // Opponent lookup — for each team in the round, who does it play against?
+  // A round typically has each team playing once, but handles multi-match teams too.
+  const opponentsByTeam = useMemo(() => {
+    const map = new Map<string, string[]>();
+    const matches = (round?.matches ?? []) as Array<{
+      teamHome: string;
+      teamAway: string;
+    }>;
+    for (const m of matches) {
+      if (!map.has(m.teamHome)) map.set(m.teamHome, []);
+      if (!map.has(m.teamAway)) map.set(m.teamAway, []);
+      map.get(m.teamHome)!.push(m.teamAway);
+      map.get(m.teamAway)!.push(m.teamHome);
+    }
+    return map;
+  }, [round?.matches]);
+
+  // ── AI queries (scoped to the round's first/opening match) ────────
+  // Pass players:[] — the server-side resolver looks them up from matchId to
+  // avoid stuffing 100+ players into a GET URL (hits ~20KB and gets rejected).
+  const projectionsQuery = trpc.analytics.getPlayerProjections.useQuery(
+    {
+      matchId: firstMatch?.id ?? "",
+      teamA: firstMatch?.teamHome ?? "",
+      teamB: firstMatch?.teamAway ?? "",
+      format: firstMatch?.format ?? "T20",
+      venue: firstMatch?.venue ?? null,
+      tournament: firstMatch?.tournament ?? "unknown",
+      players: [],
+    },
+    {
+      enabled: !!firstMatch && canAccess("hasProjectedPoints"),
+      staleTime: 60 * 60_000,
+      retry: 1,
+    }
+  );
+
+  const projectionsByPlayerId = useMemo(() => {
+    const map = new Map<string, Projection>();
+    const players = (projectionsQuery.data as any)?.players;
+    if (!Array.isArray(players)) return map;
+    for (const p of players) {
+      map.set(p.playerId, {
+        projectedPoints: Number(p.projectedPoints),
+        captainRank: Number(p.captainRank ?? 999),
+      });
+    }
+    return map;
+  }, [projectionsQuery.data]);
+
+  const playingXIQuery = trpc.analytics.getPlayingXI.useQuery(
+    {
+      matchId: firstMatch?.id ?? "",
+      teamA: firstMatch?.teamHome ?? "",
+      teamB: firstMatch?.teamAway ?? "",
+      format: firstMatch?.format ?? "T20",
+      venue: firstMatch?.venue ?? null,
+      tournament: firstMatch?.tournament ?? "unknown",
+    },
+    {
+      enabled: !!firstMatch && canAccess("hasPlayingXI"),
+      staleTime: 60 * 60_000,
+      retry: 1,
+    }
+  );
+
+  const playingXIStatus = useMemo(() => {
+    const map = new Map<string, "likely" | "bench">();
+    const data = playingXIQuery.data as any;
+    if (!data) return map;
+    for (const side of [data.teamA, data.teamB]) {
+      if (!side) continue;
+      for (const p of side.predictedXI ?? [])
+        map.set(p.name?.toLowerCase?.() ?? "", "likely");
+      for (const p of side.benchPlayers ?? [])
+        map.set(p.name?.toLowerCase?.() ?? "", "bench");
+    }
+    return map;
+  }, [playingXIQuery.data]);
+
+  const differentialsQuery = trpc.analytics.getDifferentials.useQuery(
+    {
+      matchId: firstMatch?.id ?? "",
+      teamA: firstMatch?.teamHome ?? "",
+      teamB: firstMatch?.teamAway ?? "",
+      format: firstMatch?.format ?? "T20",
+      venue: firstMatch?.venue ?? null,
+      tournament: firstMatch?.tournament ?? "unknown",
+      players: [],
+    },
+    {
+      enabled: !!firstMatch && canAccess("hasDifferentials"),
+      staleTime: 2 * 60 * 60_000,
+      retry: 1,
+    }
+  );
+
+  const differentialNames = useMemo(() => {
+    const set = new Set<string>();
+    const picks = (differentialsQuery.data as any)?.picks;
+    if (Array.isArray(picks)) {
+      for (const p of picks) set.add(p.playerName?.toLowerCase?.() ?? "");
+    }
+    return set;
+  }, [differentialsQuery.data]);
+
+  // ── Player list filtered + sorted by current tab / smart filter ───
+  const roleCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const id of selectedIds) {
+      const p = byId.get(id);
+      if (p) counts[p.role] = (counts[p.role] ?? 0) + 1;
+    }
+    return counts;
+  }, [selectedIds, byId]);
+
+  const currentRolePlayers = useMemo(() => {
+    let list: EligiblePlayer[];
+    if (selectedTab === "picked") {
+      // Preserve selection order so users can see their pick sequence
+      const selectedSet = new Set(selectedIds);
+      list = selectedIds
+        .map((id) => byId.get(id))
+        .filter((p): p is EligiblePlayer => !!p && selectedSet.has(p.playerId));
+    } else {
+      const tab = ROLE_TABS.find((t) => t.key === selectedTab) ?? ROLE_TABS[1]!;
+      list = eligible.filter((p) => tab.match(p.role));
+    }
+
+    const q = search.trim().toLowerCase();
+    if (q) {
+      list = list.filter(
+        (p) =>
+          p.name.toLowerCase().includes(q) ||
+          p.team.toLowerCase().includes(q)
+      );
+    }
+
+    // Picked tab preserves selection order — no sort/smart-filter applied
+    if (selectedTab === "picked") {
+      return list;
+    }
+
+    if (smartFilter === "differentials" && differentialNames.size > 0) {
+      list = list.filter((p) => differentialNames.has(p.name.toLowerCase()));
+    } else if (smartFilter === "value" && projectionsByPlayerId.size > 0) {
+      list = [...list].sort((a, b) => {
+        const pA = projectionsByPlayerId.get(a.playerId)?.projectedPoints ?? 0;
+        const pB = projectionsByPlayerId.get(b.playerId)?.projectedPoints ?? 0;
+        return pB - pA;
+      });
+    } else if (smartFilter === "form") {
+      // Sort by recent SR (for batters) / 1/ER (for bowlers) as a form proxy
+      list = [...list].sort((a, b) => {
+        const fA =
+          canBowl(a.role) && a.recentEcon
+            ? 10 - a.recentEcon
+            : a.recentSr ?? 0;
+        const fB =
+          canBowl(b.role) && b.recentEcon
+            ? 10 - b.recentEcon
+            : b.recentSr ?? 0;
+        return fB - fA;
+      });
+    } else if (sortBy === "projected" && projectionsByPlayerId.size > 0) {
+      list = [...list].sort((a, b) => {
+        const pA = projectionsByPlayerId.get(a.playerId)?.projectedPoints ?? 0;
+        const pB = projectionsByPlayerId.get(b.playerId)?.projectedPoints ?? 0;
+        return pB - pA;
+      });
+    } else {
+      // Default: sort by strike rate / inverse economy (form proxy)
+      list = [...list].sort((a, b) => {
+        const fA = a.recentSr ?? 0;
+        const fB = b.recentSr ?? 0;
+        return fB - fA;
+      });
+    }
+
+    return list;
+  }, [
+    eligible,
+    selectedTab,
+    selectedIds,
+    byId,
+    search,
+    smartFilter,
+    sortBy,
+    projectionsByPlayerId,
+    differentialNames,
+  ]);
+
+  // ── Actions ───────────────────────────────────────────────────────
+  const bowlerCount = useMemo(
+    () =>
+      selectedIds.filter((id) => {
+        const p = byId.get(id);
+        return p && canBowl(p.role);
+      }).length,
+    [selectedIds, byId]
+  );
+
+  function showAlert(title: string, message?: string, onConfirm?: () => void) {
+    setAlert({ title, message: message ?? "", onConfirm });
+  }
+
+  function togglePlayer(playerId: string) {
+    const player = byId.get(playerId);
+    if (!player) return;
+
+    if (selectedIds.includes(playerId)) {
+      setSelectedIds(selectedIds.filter((id) => id !== playerId));
+      setBattingOrder(battingOrder.filter((id) => id !== playerId));
+      setBowlingPriority(bowlingPriority.filter((id) => id !== playerId));
+      return;
+    }
+    if (selectedIds.length >= TEAM_SIZE) {
+      showAlert("squad full", `max ${TEAM_SIZE} players allowed`);
+      return;
+    }
+    const newIds = [...selectedIds, playerId];
+    setSelectedIds(newIds);
+    setBattingOrder([...battingOrder, playerId]);
+    if (canBowl(player.role)) {
+      setBowlingPriority([...bowlingPriority, playerId]);
+    }
+  }
+
+  function moveUp(list: string[], setList: (l: string[]) => void, i: number) {
+    if (i === 0) return;
+    const copy = [...list];
+    [copy[i - 1]!, copy[i]!] = [copy[i]!, copy[i - 1]!];
+    setList(copy);
+  }
+
+  function moveDown(list: string[], setList: (l: string[]) => void, i: number) {
+    if (i === list.length - 1) return;
+    const copy = [...list];
+    [copy[i + 1]!, copy[i]!] = [copy[i]!, copy[i + 1]!];
+    setList(copy);
+  }
+
+  function gotoStep(next: Step) {
+    if (!round) return;
+    if (next === "batting") {
+      if (selectedIds.length !== TEAM_SIZE) {
+        showAlert(
+          "squad incomplete",
+          `pick exactly ${TEAM_SIZE} players (you have ${selectedIds.length})`
+        );
+        return;
+      }
+      if (bowlerCount < round.minBowlers) {
+        showAlert(
+          "not enough bowlers",
+          `need at least ${round.minBowlers} bowlers or all-rounders (you have ${bowlerCount})`
+        );
+        return;
+      }
+    }
+    if (next === "bowling" && battingOrder.length !== 11) {
+      showAlert("set batting order", "arrange all 11 players in batting order");
+      return;
+    }
+    if (next === "review" && bowlingPriority.length === 0) {
+      showAlert("set bowling order", "add at least one bowler to the bowling order");
+      return;
+    }
+    setStep(next);
+  }
+
+  function handleSubmit() {
+    if (selectedIds.length !== TEAM_SIZE) return;
+    submit.mutate({
+      roundId: roundId!,
+      players: selectedIds.map((playerId) => ({ playerId })),
+      battingOrder: battingOrder.map((playerId, i) => ({
+        position: i + 1,
+        playerId,
+      })),
+      bowlingPriority: bowlingPriority.map((playerId, i) => ({
+        priority: i + 1,
+        playerId,
+      })),
+      toss,
+    });
+  }
+
+  // ── Projected NRR for review step ─────────────────────────────────
+  const projectedTotals = useMemo(() => {
+    if (projectionsByPlayerId.size === 0) return null;
+    let total = 0;
+    let withData = 0;
+    for (const id of selectedIds) {
+      const p = byId.get(id);
+      const proj = projectionsByPlayerId.get(id);
+      if (!p || !proj) continue;
+      total += proj.projectedPoints;
+      withData += 1;
+    }
+    if (withData === 0) return null;
+    return { total, withData, total_squad: selectedIds.length };
+  }, [selectedIds, byId, projectionsByPlayerId]);
+
+  // ── Estimated bat/bowl totals for scenario preview ────────────────
+  // Uses the same projections AI gives us, partitioned by role. These are
+  // rough — the real engine runs against live match data on settlement —
+  // but they're directionally correct and give the user a feel for how
+  // their toss call shifts the scenario.
+  const scenarioEstimate = useMemo(() => {
+    if (projectionsByPlayerId.size === 0) return null;
+    let batPts = 0;
+    let bowlPts = 0;
+    for (const id of battingOrder) {
+      const p = byId.get(id);
+      const proj = projectionsByPlayerId.get(id);
+      if (!p || !proj) continue;
+      batPts += proj.projectedPoints;
+    }
+    for (const id of bowlingPriority) {
+      const p = byId.get(id);
+      const proj = projectionsByPlayerId.get(id);
+      if (!p || !proj) continue;
+      bowlPts += proj.projectedPoints;
+    }
+    if (batPts === 0 && bowlPts === 0) return null;
+    // Scale projected points into "feels like" run totals.
+    // A 30-pt projected batter ≈ 30-40 runs in a T20; 25-pt bowler ≈ economy 8 over 4 overs ≈ 32 conceded.
+    // Keep the scaling visible but not wildly off.
+    const battingTotal = Math.round(batPts * 0.9);
+    const bowlingTotal = Math.round(bowlPts * 0.75);
+    return { battingTotal, bowlingTotal };
+  }, [battingOrder, bowlingPriority, byId, projectionsByPlayerId]);
+
+  // NrrScenarioPreview — closure over the live squad state
+  function NrrScenarioPreview({ toss }: { toss: "bat_first" | "bowl_first" }) {
+    if (!scenarioEstimate) {
+      return (
+        <Card
+          padding="$3"
+          backgroundColor="$backgroundSurfaceAlt"
+          borderWidth={0}
+        >
+          <Text
+            fontFamily="$body"
+            fontSize={10}
+            color="$colorMuted"
+            textAlign="center"
+          >
+            {formatUIText("projection preview unavailable for this squad")}
+          </Text>
+        </Card>
+      );
+    }
+
+    const batRaw = scenarioEstimate.battingTotal;
+    const bowlRaw = scenarioEstimate.bowlingTotal;
+
+    // bat_first: batters bat freely, bowl total is whatever they concede
+    // bowl_first: bowlers go first, batters chase bowlRaw + 1 (cap at what they can reach)
+    const isBatFirst = toss === "bat_first";
+    const finalBat = isBatFirst
+      ? batRaw
+      : Math.min(batRaw, bowlRaw + 1);
+    const finalBowl = bowlRaw;
+    const nrr = finalBat / 20 - finalBowl / 20;
+    const maxTotal = Math.max(finalBat, finalBowl, 1);
+
+    return (
+      <YStack gap="$2">
+        <Text
+          fontFamily="$mono"
+          fontSize={9}
+          color="$colorMuted"
+          textTransform="uppercase"
+          letterSpacing={1}
+        >
+          {formatUIText("projected for your squad")}
+        </Text>
+
+        {/* Bat bar */}
+        <ScenarioBar
+          label="your batting"
+          value={finalBat}
+          max={maxTotal}
+          color="$accentBackground"
+          capped={!isBatFirst && batRaw > bowlRaw + 1}
+        />
+        {/* Bowl bar */}
+        <ScenarioBar
+          label="opposition runs"
+          value={finalBowl}
+          max={maxTotal}
+          color="$colorCricket"
+        />
+
+        {/* NRR equation */}
+        <XStack
+          marginTop="$2"
+          padding="$2"
+          backgroundColor="$backgroundSurfaceAlt"
+          borderRadius={8}
+          alignItems="center"
+          justifyContent="space-between"
+          flexWrap="wrap"
+        >
+          <Text fontFamily="$mono" fontSize={10} color="$colorMuted">
+            {finalBat}/20 − {finalBowl}/20
+          </Text>
+          <Text
+            fontFamily="$mono"
+            fontWeight="800"
+            fontSize={16}
+            color={nrr >= 0 ? "$accentBackground" : "$colorHatch"}
+          >
+            NRR {nrr >= 0 ? "+" : ""}
+            {nrr.toFixed(2)}
+          </Text>
+        </XStack>
+
+        {!isBatFirst && batRaw > bowlRaw + 1 && (
+          <Text
+            fontFamily="$body"
+            fontSize={10}
+            color="$colorMuted"
+            lineHeight={13}
+          >
+            {formatUIText(
+              `chasing stops at ${bowlRaw + 1} — your extra ${batRaw - (bowlRaw + 1)} batting runs don't count`
+            )}
+          </Text>
+        )}
+      </YStack>
+    );
+  }
+
+  // ── Risk flags (review step) ──────────────────────────────────────
+  const riskFlags = useMemo(() => {
+    const flags: Array<{ icon: string; text: string }> = [];
+
+    // Bench risk
+    const benchCount = selectedIds.filter(
+      (id) =>
+        playingXIStatus.get(byId.get(id)?.name.toLowerCase() ?? "") === "bench"
+    ).length;
+    if (benchCount > 0) {
+      flags.push({
+        icon: "⚠️",
+        text: `${benchCount} player${benchCount > 1 ? "s have" : " has"} bench risk`,
+      });
+    }
+
+    // Team skew
+    const teamCounts: Record<string, number> = {};
+    for (const id of selectedIds) {
+      const p = byId.get(id);
+      if (p) teamCounts[p.team] = (teamCounts[p.team] ?? 0) + 1;
+    }
+    for (const [team, c] of Object.entries(teamCounts)) {
+      if (c >= 8) {
+        flags.push({
+          icon: "⚠️",
+          text: `${c} players from ${team} — heavily skewed`,
+        });
+      }
+    }
+
+    return flags;
+  }, [selectedIds, byId, playingXIStatus]);
+
+  // ── Loading ──
+  if (roundQuery.isLoading || !round) {
+    return (
+      <YStack
+        flex={1}
+        backgroundColor="$background"
+        justifyContent="center"
+        alignItems="center"
+      >
+        <EggLoadingSpinner size={48} message="loading" />
+      </YStack>
+    );
+  }
+
+  // ─────────────────────────────────────────────────────────────────
+  // Render
+  // ─────────────────────────────────────────────────────────────────
+  return (
+    <YStack flex={1} backgroundColor="$background">
+      {/* ── Header ─────────────────────────────────────────────── */}
+      <XStack
+        justifyContent="space-between"
+        alignItems="center"
+        paddingHorizontal="$4"
+        paddingTop={insets.top + 8}
+        paddingBottom="$3"
+      >
+        <XStack alignItems="center" gap="$3" flex={1}>
+          <SafeBackButton />
+          <Text
+            fontFamily="$mono"
+            fontWeight="500"
+            fontSize={17}
+            color="$color"
+            letterSpacing={-0.5}
+          >
+            {formatUIText("build entry")}
+          </Text>
+        </XStack>
+        <XStack alignItems="center" gap="$2">
+          <Pressable
+            onPress={() => setShowGuru(true)}
+            hitSlop={8}
+            style={{ padding: 4 }}
+            testID="cm-guru-btn"
+          >
+            <Text fontSize={20}>✨</Text>
+          </Pressable>
+          <Pressable
+            onPress={() => setShowExplainer(true)}
+            hitSlop={8}
+            style={{ padding: 4 }}
+          >
+            <Ionicons
+              name="help-circle-outline"
+              size={22}
+              color={theme.colorMuted?.val ?? "#888"}
+            />
+          </Pressable>
+          <HeaderControls />
+        </XStack>
+      </XStack>
+
+      {/* ── Step indicator ─────────────────────────────────────── */}
+      <StepIndicator step={step} />
+
+      {/* ── Round summary bar ──────────────────────────────────── */}
+      {step === "squad" && (
+        <XStack
+          paddingHorizontal="$4"
+          paddingVertical="$2"
+          gap="$3"
+          borderBottomWidth={1}
+          borderBottomColor="$borderColor"
+          backgroundColor="$backgroundSurface"
+        >
+          <Text
+            fontFamily="$mono"
+            fontSize={11}
+            color="$accentBackground"
+            fontWeight="700"
+          >
+            {round.name}
+          </Text>
+          <Text fontFamily="$mono" fontSize={10} color="$colorMuted">
+            {round.matchesTotal} {formatUIText("matches")}
+          </Text>
+          <Text
+            fontFamily="$mono"
+            fontSize={10}
+            color={
+              selectedIds.length === TEAM_SIZE
+                ? "$accentBackground"
+                : "$colorMuted"
+            }
+          >
+            {selectedIds.length}/{TEAM_SIZE}
+          </Text>
+          <Text
+            fontFamily="$mono"
+            fontSize={10}
+            color={
+              bowlerCount >= round.minBowlers
+                ? "$accentBackground"
+                : "$colorMuted"
+            }
+          >
+            {bowlerCount}/{round.minBowlers} bowl
+          </Text>
+        </XStack>
+      )}
+
+      {/* ── STEP: SQUAD ─────────────────────────────────────────── */}
+      {step === "squad" && (
+        <>
+          {/* Selected squad strip — always visible for quick review + deselect */}
+          {selectedIds.length > 0 && (
+            <YStack
+              paddingVertical="$2"
+              backgroundColor="$backgroundSurface"
+              borderBottomWidth={1}
+              borderBottomColor="$borderColor"
+            >
+              <XStack
+                paddingHorizontal="$4"
+                marginBottom="$2"
+                alignItems="center"
+                justifyContent="space-between"
+              >
+                <Text
+                  fontFamily="$mono"
+                  fontSize={10}
+                  color="$colorMuted"
+                  textTransform="uppercase"
+                  letterSpacing={1}
+                >
+                  {formatUIText("your squad")} · {selectedIds.length}/{TEAM_SIZE}
+                </Text>
+                <Pressable
+                  onPress={() =>
+                    setSelectedTab(selectedTab === "picked" ? "all" : "picked")
+                  }
+                  hitSlop={6}
+                >
+                  <Text
+                    fontFamily="$mono"
+                    fontSize={10}
+                    color="$accentBackground"
+                    fontWeight="700"
+                  >
+                    {selectedTab === "picked"
+                      ? formatUIText("show all →")
+                      : formatUIText("view all →")}
+                  </Text>
+                </Pressable>
+              </XStack>
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerStyle={{
+                  paddingHorizontal: 16,
+                  gap: 10,
+                  alignItems: "center",
+                }}
+              >
+                {selectedIds.map((pid) => {
+                  const p = byId.get(pid);
+                  if (!p) return null;
+                  return (
+                    <Pressable
+                      key={pid}
+                      onPress={() => togglePlayer(pid)}
+                      hitSlop={4}
+                    >
+                      <YStack alignItems="center" width={44}>
+                        <YStack position="relative">
+                          <InitialsAvatar
+                            name={p.name}
+                            playerRole={roleToBadge(p.role)}
+                            ovr={0}
+                            size={36}
+                            hideBadge
+                            imageUrl={p.photoUrl ?? undefined}
+                          />
+                          {/* tiny × overlay to signal tap-to-remove */}
+                          <YStack
+                            position="absolute"
+                            top={-4}
+                            right={-4}
+                            width={16}
+                            height={16}
+                            borderRadius={8}
+                            backgroundColor="$backgroundSurface"
+                            borderWidth={1}
+                            borderColor="$borderColor"
+                            alignItems="center"
+                            justifyContent="center"
+                          >
+                            <Text
+                              fontFamily="$mono"
+                              fontSize={10}
+                              fontWeight="700"
+                              color="$colorMuted"
+                              lineHeight={10}
+                            >
+                              ×
+                            </Text>
+                          </YStack>
+                        </YStack>
+                        <Text
+                          fontFamily="$body"
+                          fontSize={9}
+                          color="$color"
+                          numberOfLines={1}
+                          marginTop={4}
+                          textAlign="center"
+                        >
+                          {p.name.split(" ").pop() ?? p.name}
+                        </Text>
+                      </YStack>
+                    </Pressable>
+                  );
+                })}
+                {/* Empty slots placeholder */}
+                {Array.from({ length: TEAM_SIZE - selectedIds.length }).map(
+                  (_, i) => (
+                    <YStack
+                      key={`empty-${i}`}
+                      width={36}
+                      height={36}
+                      borderRadius={10}
+                      borderWidth={1}
+                      borderColor="$borderColor"
+                      borderStyle="dashed"
+                      alignItems="center"
+                      justifyContent="center"
+                      opacity={0.4}
+                    >
+                      <Text
+                        fontFamily="$mono"
+                        fontSize={10}
+                        color="$colorMuted"
+                      >
+                        {selectedIds.length + i + 1}
+                      </Text>
+                    </YStack>
+                  )
+                )}
+              </ScrollView>
+            </YStack>
+          )}
+
+          {/* Search bar */}
+          <XStack
+            paddingHorizontal="$3"
+            paddingVertical="$2"
+            backgroundColor="$backgroundSurface"
+            borderBottomWidth={1}
+            borderBottomColor="$borderColor"
+          >
+            <XStack
+              flex={1}
+              backgroundColor="$backgroundSurfaceAlt"
+              borderRadius={10}
+              paddingHorizontal="$3"
+              paddingVertical="$2"
+              alignItems="center"
+              gap="$2"
+            >
+              <Ionicons
+                name="search"
+                size={14}
+                color={theme.colorMuted?.val ?? "#999"}
+              />
+              <TextInput
+                placeholder="search players..."
+                placeholderTextColor={theme.colorMuted?.val ?? "#999"}
+                value={search}
+                onChangeText={setSearch}
+                style={{
+                  flex: 1,
+                  color: theme.color?.val ?? "#000",
+                  fontSize: 13,
+                  padding: 0,
+                }}
+              />
+              {search.length > 0 && (
+                <Pressable onPress={() => setSearch("")} hitSlop={8}>
+                  <Ionicons
+                    name="close-circle"
+                    size={16}
+                    color={theme.colorMuted?.val ?? "#666"}
+                  />
+                </Pressable>
+              )}
+            </XStack>
+          </XStack>
+
+          {/* Role tabs */}
+          <XStack
+            paddingHorizontal="$3"
+            paddingVertical="$2"
+            gap="$2"
+            flexWrap="wrap"
+          >
+            {ROLE_TABS.map((tab) => {
+              const count =
+                tab.key === "picked"
+                  ? selectedIds.length
+                  : tab.key === "all"
+                  ? 0
+                  : roleCounts[tab.key] ?? 0;
+              const isActive = selectedTab === tab.key;
+              // Don't show "picked" tab at all until something is selected
+              if (tab.key === "picked" && count === 0) return null;
+              return (
+                <FilterPill
+                  key={tab.key}
+                  active={isActive}
+                  onPress={() => setSelectedTab(tab.key)}
+                >
+                  <Text
+                    fontFamily="$body"
+                    fontWeight="700"
+                    fontSize={13}
+                    color={isActive ? "$background" : "$colorSecondary"}
+                  >
+                    {tab.label}
+                    {count > 0 ? ` · ${count}` : ""}
+                  </Text>
+                </FilterPill>
+              );
+            })}
+          </XStack>
+
+          {/* Sort toggles */}
+          <XStack
+            justifyContent="space-between"
+            alignItems="center"
+            paddingHorizontal="$4"
+            marginBottom="$1"
+          >
+            <Text fontFamily="$body" fontSize={12} color="$colorMuted">
+              {formatUIText(`min ${round.minBowlers} bowlers (bowler or all-rounder)`)}
+            </Text>
+            <XStack gap="$1">
+              <FilterPill
+                active={sortBy === "form"}
+                onPress={() => {
+                  setSortBy("form");
+                  setSmartFilter("all");
+                }}
+              >
+                <Text
+                  fontFamily="$mono"
+                  fontSize={9}
+                  fontWeight="700"
+                  color={sortBy === "form" ? "$background" : "$colorMuted"}
+                >
+                  {formatBadgeText("form")}
+                </Text>
+              </FilterPill>
+              {projectionsByPlayerId.size > 0 ? (
+                <FilterPill
+                  active={sortBy === "projected" && smartFilter === "all"}
+                  onPress={() => {
+                    setSortBy("projected");
+                    setSmartFilter("all");
+                  }}
+                >
+                  <Text
+                    fontFamily="$mono"
+                    fontSize={9}
+                    fontWeight="700"
+                    color={
+                      sortBy === "projected" && smartFilter === "all"
+                        ? "$background"
+                        : "$colorMuted"
+                    }
+                  >
+                    {formatBadgeText("projected")}
+                  </Text>
+                </FilterPill>
+              ) : !canAccess("hasProjectedPoints") ? (
+                <Pressable
+                  onPress={() =>
+                    gateFeature(
+                      "hasProjectedPoints",
+                      "pro",
+                      "Projected Points",
+                      "AI-estimated fantasy points for each player"
+                    )
+                  }
+                >
+                  <XStack
+                    paddingHorizontal={10}
+                    paddingVertical={6}
+                    borderRadius={14}
+                    borderWidth={1}
+                    borderColor="$borderColor"
+                    backgroundColor="$backgroundSurface"
+                    alignItems="center"
+                    gap={4}
+                    opacity={0.5}
+                  >
+                    <Text
+                      fontFamily="$mono"
+                      fontSize={9}
+                      fontWeight="700"
+                      color="$colorMuted"
+                    >
+                      {formatBadgeText("projected")}
+                    </Text>
+                    <TierBadge tier="pro" size="sm" />
+                  </XStack>
+                </Pressable>
+              ) : null}
+            </XStack>
+          </XStack>
+
+          {/* Smart Picks filter strip */}
+          {selectedIds.length >= 3 && projectionsByPlayerId.size > 0 && (
+            <XStack
+              paddingHorizontal="$4"
+              paddingBottom="$2"
+              gap="$2"
+              flexWrap="wrap"
+            >
+              <SmartPill
+                emoji="🔮"
+                label="ai top"
+                active={smartFilter === "all" && sortBy === "projected"}
+                onPress={() => {
+                  setSmartFilter("all");
+                  setSortBy("projected");
+                }}
+              />
+              {differentialNames.size > 0 ? (
+                <SmartPill
+                  emoji="💎"
+                  label="diffs"
+                  active={smartFilter === "differentials"}
+                  onPress={() => setSmartFilter("differentials")}
+                />
+              ) : !canAccess("hasDifferentials") ? (
+                <Pressable
+                  onPress={() =>
+                    gateFeature(
+                      "hasDifferentials",
+                      "pro",
+                      "Differentials",
+                      "Low-ownership high-upside picks"
+                    )
+                  }
+                >
+                  <XStack
+                    paddingHorizontal={10}
+                    paddingVertical={5}
+                    borderRadius={14}
+                    borderWidth={1}
+                    borderColor="$borderColor"
+                    backgroundColor="$backgroundSurface"
+                    alignItems="center"
+                    gap={4}
+                    opacity={0.5}
+                  >
+                    <Text fontSize={10}>💎</Text>
+                    <Text
+                      fontFamily="$mono"
+                      fontSize={9}
+                      fontWeight="700"
+                      color="$colorMuted"
+                    >
+                      {formatBadgeText("diffs")}
+                    </Text>
+                    <TierBadge tier="pro" size="sm" />
+                  </XStack>
+                </Pressable>
+              ) : null}
+              <SmartPill
+                emoji="📈"
+                label="value"
+                active={smartFilter === "value"}
+                onPress={() => setSmartFilter("value")}
+              />
+              <SmartPill
+                emoji="🔥"
+                label="form"
+                active={smartFilter === "form"}
+                onPress={() => setSmartFilter("form")}
+              />
+            </XStack>
+          )}
+
+          {/* Player list */}
+          <ScrollView
+            style={{ flex: 1 }}
+            contentContainerStyle={{ paddingHorizontal: 12, paddingBottom: 16 }}
+          >
+            {currentRolePlayers.length > 0 ? (
+              currentRolePlayers.map((player, i) => {
+                const isSelected = selectedIds.includes(player.playerId);
+                const isDisabled =
+                  !isSelected && selectedIds.length >= TEAM_SIZE;
+                const proj = projectionsByPlayerId.get(player.playerId);
+                const xiStatus = playingXIStatus.get(player.name.toLowerCase());
+                const isDiff = differentialNames.has(player.name.toLowerCase());
+                return (
+                  <Animated.View
+                    key={player.playerId}
+                    entering={FadeInDown.delay(Math.min(i * 20, 300)).springify()}
+                  >
+                    <Card
+                      marginBottom="$1"
+                      padding={0}
+                      borderColor={
+                        isSelected ? "$accentBackground" : "$borderColor"
+                      }
+                      borderWidth={isSelected ? 2 : 1}
+                      backgroundColor={
+                        isSelected
+                          ? "$backgroundSurfaceAlt"
+                          : "$backgroundSurface"
+                      }
+                      opacity={isDisabled && !isSelected ? 0.4 : 1}
+                    >
+                      <XStack alignItems="center">
+                        {/* Main row — tap to select */}
+                        <Pressable
+                          onPress={() => togglePlayer(player.playerId)}
+                          disabled={isDisabled && !isSelected}
+                          style={{ flex: 1 }}
+                        >
+                          <XStack
+                            alignItems="center"
+                            paddingVertical={12}
+                            paddingLeft={12}
+                            paddingRight={8}
+                          >
+                            <InitialsAvatar
+                              name={player.name}
+                              playerRole={roleToBadge(player.role)}
+                              ovr={0}
+                              size={40}
+                              hideBadge
+                              imageUrl={player.photoUrl ?? undefined}
+                            />
+                            <YStack flex={1} marginLeft="$3">
+                              {/* Line 1: Name + badges */}
+                              <XStack
+                                alignItems="center"
+                                gap="$1"
+                                flexWrap="wrap"
+                              >
+                                <Text {...textStyles.playerName} numberOfLines={1}>
+                                  {player.name}
+                                </Text>
+                                {proj && proj.captainRank <= 3 && (
+                                  <Text fontSize={10} lineHeight={12}>
+                                    👑
+                                  </Text>
+                                )}
+                                {isDiff && (
+                                  <Text
+                                    fontSize={10}
+                                    lineHeight={12}
+                                    color="$colorCricket"
+                                  >
+                                    💎
+                                  </Text>
+                                )}
+                                {xiStatus === "likely" && (
+                                  <Badge variant="live" size="sm">
+                                    <Text
+                                      fontFamily="$mono"
+                                      fontSize={7}
+                                      fontWeight="700"
+                                      color="white"
+                                    >
+                                      {formatBadgeText("XI")}
+                                    </Text>
+                                  </Badge>
+                                )}
+                                {xiStatus === "bench" && (
+                                  <Badge variant="warning" size="sm">
+                                    <Text
+                                      fontFamily="$mono"
+                                      fontSize={7}
+                                      fontWeight="700"
+                                    >
+                                      {formatBadgeText("BENCH")}
+                                    </Text>
+                                  </Badge>
+                                )}
+                              </XStack>
+
+                              {/* Line 2: team · role · vs opponent */}
+                              <XStack alignItems="center" gap={6} marginTop={2}>
+                                <Text
+                                  fontFamily="$mono"
+                                  fontSize={11}
+                                  fontWeight="600"
+                                  color="$colorMuted"
+                                >
+                                  {teamShortCode(player.team)} · {roleToBadge(player.role)}
+                                  {(() => {
+                                    const bat = shortBatStyle(player.battingStyle);
+                                    const bowl = shortBowlStyle(player.bowlingStyle);
+                                    if (canBowl(player.role) && bowl) return ` · ${bowl}`;
+                                    if (bat) return ` · ${bat}`;
+                                    return "";
+                                  })()}
+                                </Text>
+                                {(() => {
+                                  const opponents =
+                                    opponentsByTeam.get(player.team) ?? [];
+                                  if (opponents.length === 0) return null;
+                                  const shortList = opponents
+                                    .slice(0, 2)
+                                    .map(teamShortCode)
+                                    .join(", ");
+                                  const suffix =
+                                    opponents.length > 2
+                                      ? ` +${opponents.length - 2}`
+                                      : "";
+                                  return (
+                                    <Text
+                                      fontFamily="$mono"
+                                      fontSize={11}
+                                      color="$accentBackground"
+                                      fontWeight="700"
+                                    >
+                                      vs {shortList}
+                                      {suffix}
+                                    </Text>
+                                  );
+                                })()}
+                              </XStack>
+
+                              {/* Line 3: form note (AI commentary on recent form) */}
+                              {player.formNote && (
+                                <Text
+                                  fontFamily="$body"
+                                  fontSize={10}
+                                  color="$accentBackground"
+                                  opacity={0.75}
+                                  marginTop={3}
+                                  numberOfLines={2}
+                                  lineHeight={13}
+                                >
+                                  {player.formNote}
+                                </Text>
+                              )}
+                            </YStack>
+                            {sortBy === "projected" && proj && (
+                              <YStack
+                                alignItems="center"
+                                marginRight="$2"
+                              >
+                                <Text
+                                  fontFamily="$mono"
+                                  fontWeight="800"
+                                  fontSize={17}
+                                  color="$accentBackground"
+                                >
+                                  {proj.projectedPoints.toFixed(1)}
+                                </Text>
+                                <Text {...textStyles.hint}>
+                                  {formatUIText("pts")}
+                                </Text>
+                              </YStack>
+                            )}
+                            {player.recentForm != null && sortBy !== "projected" && (
+                              <YStack
+                                alignItems="center"
+                                marginRight="$2"
+                              >
+                                <Text
+                                  fontFamily="$mono"
+                                  fontWeight="800"
+                                  fontSize={15}
+                                  color={
+                                    player.recentForm >= 7
+                                      ? "$accentBackground"
+                                      : player.recentForm >= 4
+                                      ? "$colorCricket"
+                                      : "$colorMuted"
+                                  }
+                                >
+                                  {player.recentForm}
+                                </Text>
+                                <Text {...textStyles.hint}>form</Text>
+                              </YStack>
+                            )}
+                          </XStack>
+                        </Pressable>
+
+                        {/* Separated stats icon — its own tap target with vertical divider */}
+                        <YStack
+                          width={1}
+                          alignSelf="stretch"
+                          backgroundColor="$borderColor"
+                          marginVertical={8}
+                        />
+                        <Pressable
+                          onPress={() => setStatsPlayerId(player.playerId)}
+                          hitSlop={6}
+                          style={{
+                            paddingVertical: 12,
+                            paddingHorizontal: 14,
+                          }}
+                        >
+                          <Ionicons
+                            name="stats-chart"
+                            size={18}
+                            color="#5DB882"
+                          />
+                        </Pressable>
+                      </XStack>
+                    </Card>
+                  </Animated.View>
+                );
+              })
+            ) : (
+              <Card padding="$8" alignItems="center">
+                <DraftPlayLogo size={DesignSystem.emptyState.iconSize} />
+                <Text {...textStyles.hint} textAlign="center" lineHeight={20}>
+                  {selectedTab === "picked"
+                    ? formatUIText(
+                        "no players picked yet — switch to any tab to start selecting"
+                      )
+                    : search.trim()
+                    ? formatUIText("no players match your search")
+                    : formatUIText(
+                        "player pool not populated yet — check back closer to match time"
+                      )}
+                </Text>
+              </Card>
+            )}
+          </ScrollView>
+        </>
+      )}
+
+      {/* ── STEP: BATTING ORDER ─────────────────────────────────── */}
+      {step === "batting" && (() => {
+        // Compute the "ball usage cutoff" — at which batting position does the
+        // 120-ball budget run out, given each batter's typical balls faced.
+        // Heuristic: high-SR players face ~20 balls, low-SR ~30. Default 25.
+        const ballEstimate = (sr?: number) => {
+          if (!sr || sr === 0) return 25;
+          if (sr >= 160) return 18;
+          if (sr >= 130) return 23;
+          if (sr >= 100) return 28;
+          return 35;
+        };
+        let cumBalls = 0;
+        let cutoffIdx = -1;
+        for (let i = 0; i < battingOrder.length; i++) {
+          const p = byId.get(battingOrder[i]!);
+          cumBalls += ballEstimate(p?.recentSr);
+          if (cumBalls >= 120 && cutoffIdx === -1) {
+            cutoffIdx = i;
+            break;
+          }
+        }
+
+        return (
+          <ScrollView
+            style={{ flex: 1 }}
+            contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 16 }}
+          >
+            <Text
+              fontFamily="$body"
+              fontSize={12}
+              color="$colorMuted"
+              paddingVertical="$3"
+            >
+              {formatUIText(
+                "tap arrows to reorder. high-SR openers at top — players below the cutoff line may not face balls."
+              )}
+            </Text>
+            {battingOrder.map((pid, i) => {
+              const p = byId.get(pid);
+              if (!p) return null;
+              const proj = projectionsByPlayerId.get(pid);
+              const opponents = opponentsByTeam.get(p.team) ?? [];
+              const opponentStr =
+                opponents.length > 0
+                  ? opponents.slice(0, 2).map(teamShortCode).join(", ") +
+                    (opponents.length > 2 ? ` +${opponents.length - 2}` : "")
+                  : undefined;
+              return (
+                <YStack key={pid}>
+                  <OrderRow
+                    player={p}
+                    position={i + 1}
+                    accentColor="$accentBackground"
+                    projected={proj?.projectedPoints}
+                    opponent={opponentStr}
+                    onUp={() => moveUp(battingOrder, setBattingOrder, i)}
+                    onDown={() => moveDown(battingOrder, setBattingOrder, i)}
+                    upDisabled={i === 0}
+                    downDisabled={i === battingOrder.length - 1}
+                  />
+                  {i === cutoffIdx && (
+                    <XStack
+                      alignItems="center"
+                      gap="$2"
+                      marginVertical="$2"
+                      paddingHorizontal="$2"
+                    >
+                      <YStack
+                        flex={1}
+                        height={1}
+                        backgroundColor="$colorCricket"
+                        opacity={0.4}
+                      />
+                      <Text
+                        fontFamily="$mono"
+                        fontSize={9}
+                        fontWeight="700"
+                        color="$colorCricket"
+                        textTransform="uppercase"
+                        letterSpacing={1}
+                      >
+                        ⚡ ~120 balls used here
+                      </Text>
+                      <YStack
+                        flex={1}
+                        height={1}
+                        backgroundColor="$colorCricket"
+                        opacity={0.4}
+                      />
+                    </XStack>
+                  )}
+                </YStack>
+              );
+            })}
+          </ScrollView>
+        );
+      })()}
+
+      {/* ── STEP: BOWLING PRIORITY ──────────────────────────────── */}
+      {step === "bowling" && (
+        <ScrollView
+          style={{ flex: 1 }}
+          contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 16 }}
+        >
+          <Text
+            fontFamily="$body"
+            fontSize={12}
+            color="$colorMuted"
+            paddingVertical="$3"
+          >
+            {formatUIText(
+              "tap arrows to reorder. bowlers bowl in this order. each capped at 4 overs. bowling stops if 10 wickets fall."
+            )}
+          </Text>
+          {bowlingPriority.map((pid, i) => {
+            const p = byId.get(pid);
+            if (!p) return null;
+            const proj = projectionsByPlayerId.get(pid);
+            const opponents = opponentsByTeam.get(p.team) ?? [];
+            const opponentStr =
+              opponents.length > 0
+                ? opponents.slice(0, 2).map(teamShortCode).join(", ") +
+                  (opponents.length > 2 ? ` +${opponents.length - 2}` : "")
+                : undefined;
+            return (
+              <OrderRow
+                key={pid}
+                player={p}
+                position={i + 1}
+                accentColor="$colorCricket"
+                projected={proj?.projectedPoints}
+                opponent={opponentStr}
+                onUp={() =>
+                  moveUp(bowlingPriority, setBowlingPriority, i)
+                }
+                onDown={() =>
+                  moveDown(bowlingPriority, setBowlingPriority, i)
+                }
+                upDisabled={i === 0}
+                downDisabled={i === bowlingPriority.length - 1}
+              />
+            );
+          })}
+        </ScrollView>
+      )}
+
+      {/* ── STEP: REVIEW ─────────────────────────────────────────── */}
+      {step === "review" && (
+        <ScrollView
+          contentContainerStyle={{ padding: 16, paddingBottom: 16 }}
+          style={{ flex: 1 }}
+        >
+          {/* Toss call — live squad-based preview of the chosen scenario */}
+          <Card padding="$4" marginBottom="$4">
+            <XStack justifyContent="space-between" alignItems="center" marginBottom="$2">
+              <Text
+                fontFamily="$mono"
+                fontSize={10}
+                color="$colorMuted"
+                textTransform="uppercase"
+                letterSpacing={1}
+              >
+                {formatUIText("toss call")}
+              </Text>
+              <Pressable
+                onPress={() => setShowExplainer(true)}
+                hitSlop={8}
+              >
+                <XStack alignItems="center" gap={4}>
+                  <Ionicons
+                    name="help-circle-outline"
+                    size={14}
+                    color={theme.colorMuted?.val ?? "#888"}
+                  />
+                  <Text fontFamily="$body" fontSize={10} color="$colorMuted">
+                    {formatUIText("how it works")}
+                  </Text>
+                </XStack>
+              </Pressable>
+            </XStack>
+
+            <XStack gap="$2" marginBottom="$3">
+              <Pressable
+                onPress={() => setToss("bat_first")}
+                style={{ flex: 1 }}
+              >
+                <YStack
+                  padding="$3"
+                  borderRadius={10}
+                  borderWidth={toss === "bat_first" ? 2 : 1}
+                  borderColor={
+                    toss === "bat_first"
+                      ? "$accentBackground"
+                      : "$borderColor"
+                  }
+                  backgroundColor={
+                    toss === "bat_first"
+                      ? "$backgroundSurfaceAlt"
+                      : "$backgroundSurface"
+                  }
+                  alignItems="center"
+                  gap={4}
+                >
+                  <Text fontSize={22}>🏏</Text>
+                  <Text
+                    fontFamily="$body"
+                    fontWeight="700"
+                    fontSize={13}
+                    color={
+                      toss === "bat_first" ? "$accentBackground" : "$color"
+                    }
+                  >
+                    {formatUIText("bat first")}
+                  </Text>
+                  <Text
+                    fontFamily="$body"
+                    fontSize={10}
+                    color="$colorMuted"
+                    textAlign="center"
+                    lineHeight={13}
+                  >
+                    {formatUIText("post a total, defend it")}
+                  </Text>
+                </YStack>
+              </Pressable>
+              <Pressable
+                onPress={() => setToss("bowl_first")}
+                style={{ flex: 1 }}
+              >
+                <YStack
+                  padding="$3"
+                  borderRadius={10}
+                  borderWidth={toss === "bowl_first" ? 2 : 1}
+                  borderColor={
+                    toss === "bowl_first"
+                      ? "$colorCricket"
+                      : "$borderColor"
+                  }
+                  backgroundColor={
+                    toss === "bowl_first"
+                      ? "$backgroundSurfaceAlt"
+                      : "$backgroundSurface"
+                  }
+                  alignItems="center"
+                  gap={4}
+                >
+                  <Text fontSize={22}>🎯</Text>
+                  <Text
+                    fontFamily="$body"
+                    fontWeight="700"
+                    fontSize={13}
+                    color={
+                      toss === "bowl_first" ? "$colorCricket" : "$color"
+                    }
+                  >
+                    {formatUIText("bowl first")}
+                  </Text>
+                  <Text
+                    fontFamily="$body"
+                    fontSize={10}
+                    color="$colorMuted"
+                    textAlign="center"
+                    lineHeight={13}
+                  >
+                    {formatUIText("restrict them, then chase")}
+                  </Text>
+                </YStack>
+              </Pressable>
+            </XStack>
+
+            {/* Scenario preview using the user's actual squad */}
+            <NrrScenarioPreview toss={toss} />
+          </Card>
+
+          {/* AI projection — scoped to round's opening fixture, so partial by design */}
+          {projectedTotals && projectedTotals.withData >= 3 && (
+            <Card
+              padding="$4"
+              marginBottom="$4"
+              borderWidth={1}
+              borderColor="$accentBackground"
+            >
+              <XStack alignItems="center" justifyContent="space-between">
+                <YStack flex={1}>
+                  <Text
+                    fontFamily="$mono"
+                    fontSize={10}
+                    color="$colorMuted"
+                    textTransform="uppercase"
+                    letterSpacing={1}
+                  >
+                    {formatUIText("ai projection")}
+                  </Text>
+                  <Text
+                    fontFamily="$body"
+                    fontSize={10}
+                    color="$colorMuted"
+                    marginTop={2}
+                  >
+                    {formatUIText("based on the round's opening fixture")} ·{" "}
+                    {projectedTotals.withData}/{projectedTotals.total_squad}{" "}
+                    {formatUIText("players")}
+                  </Text>
+                </YStack>
+                <YStack alignItems="flex-end">
+                  <Text
+                    fontFamily="$mono"
+                    fontWeight="800"
+                    fontSize={24}
+                    color="$accentBackground"
+                    letterSpacing={-0.5}
+                  >
+                    {projectedTotals.total.toFixed(0)}
+                  </Text>
+                  <Text
+                    fontFamily="$mono"
+                    fontSize={9}
+                    color="$colorMuted"
+                  >
+                    {formatUIText("proj. pts")}
+                  </Text>
+                </YStack>
+              </XStack>
+            </Card>
+          )}
+
+          {/* Risk flags */}
+          {riskFlags.length > 0 && (
+            <Card padding="$4" marginBottom="$4">
+              <Text
+                fontFamily="$mono"
+                fontSize={11}
+                color="$colorMuted"
+                textTransform="uppercase"
+                letterSpacing={1}
+                marginBottom="$2"
+              >
+                {formatUIText("risk flags")}
+              </Text>
+              {riskFlags.map((f, i) => (
+                <XStack key={i} gap="$2" marginTop="$1">
+                  <Text fontSize={12}>{f.icon}</Text>
+                  <Text
+                    fontFamily="$body"
+                    fontSize={12}
+                    color="$color"
+                    flex={1}
+                  >
+                    {f.text}
+                  </Text>
+                </XStack>
+              ))}
+            </Card>
+          )}
+
+          {/* Batting order recap */}
+          <Text
+            fontFamily="$mono"
+            fontSize={12}
+            color="$colorMuted"
+            textTransform="uppercase"
+            letterSpacing={1}
+            marginBottom="$2"
+          >
+            {formatUIText("batting order")}
+          </Text>
+          {battingOrder.map((pid, i) => {
+            const p = byId.get(pid);
+            if (!p) return null;
+            const proj = projectionsByPlayerId.get(pid);
+            const opponents = opponentsByTeam.get(p.team) ?? [];
+            const opponentStr =
+              opponents.length > 0
+                ? opponents.slice(0, 2).map(teamShortCode).join(", ") +
+                  (opponents.length > 2 ? ` +${opponents.length - 2}` : "")
+                : undefined;
+            return (
+              <OrderRow
+                key={pid}
+                player={p}
+                position={i + 1}
+                accentColor="$accentBackground"
+                projected={proj?.projectedPoints}
+                opponent={opponentStr}
+                readonly
+              />
+            );
+          })}
+
+          {/* Bowling priority recap */}
+          <Text
+            fontFamily="$mono"
+            fontSize={12}
+            color="$colorMuted"
+            textTransform="uppercase"
+            letterSpacing={1}
+            marginBottom="$2"
+            marginTop="$4"
+          >
+            {formatUIText("bowling order")}
+          </Text>
+          {bowlingPriority.map((pid, i) => {
+            const p = byId.get(pid);
+            if (!p) return null;
+            const proj = projectionsByPlayerId.get(pid);
+            const opponents = opponentsByTeam.get(p.team) ?? [];
+            const opponentStr =
+              opponents.length > 0
+                ? opponents.slice(0, 2).map(teamShortCode).join(", ") +
+                  (opponents.length > 2 ? ` +${opponents.length - 2}` : "")
+                : undefined;
+            return (
+              <OrderRow
+                key={pid}
+                player={p}
+                position={i + 1}
+                accentColor="$colorCricket"
+                projected={proj?.projectedPoints}
+                opponent={opponentStr}
+                readonly
+              />
+            );
+          })}
+        </ScrollView>
+      )}
+
+      {/* ── Sticky footer ───────────────────────────────────────── */}
+      <XStack
+        padding="$4"
+        paddingBottom={insets.bottom + 16}
+        gap="$3"
+        backgroundColor="$background"
+        borderTopWidth={1}
+        borderTopColor="$borderColor"
+      >
+        {step !== "squad" && (
+          <Button
+            variant="secondary"
+            size="lg"
+            flex={1}
+            onPress={() => {
+              if (step === "batting") setStep("squad");
+              else if (step === "bowling") setStep("batting");
+              else if (step === "review") setStep("bowling");
+            }}
+          >
+            {formatUIText("back")}
+          </Button>
+        )}
+        {step === "squad" && (
+          <Button
+            variant="primary"
+            size="lg"
+            flex={1}
+            disabled={selectedIds.length !== TEAM_SIZE}
+            opacity={selectedIds.length !== TEAM_SIZE ? 0.4 : 1}
+            onPress={() => gotoStep("batting")}
+            testID="cm-squad-continue"
+          >
+            {selectedIds.length < TEAM_SIZE
+              ? formatUIText(
+                  `select ${TEAM_SIZE - selectedIds.length} more players`
+                )
+              : formatUIText("set batting order")}
+          </Button>
+        )}
+        {step === "batting" && (
+          <Button
+            variant="primary"
+            size="lg"
+            flex={2}
+            onPress={() => gotoStep("bowling")}
+            testID="cm-batting-continue"
+          >
+            {formatUIText("set bowling order")}
+          </Button>
+        )}
+        {step === "bowling" && (
+          <Button
+            variant="primary"
+            size="lg"
+            flex={2}
+            onPress={() => gotoStep("review")}
+            testID="cm-bowling-continue"
+          >
+            {formatUIText("review")}
+          </Button>
+        )}
+        {step === "review" && (
+          <Button
+            variant="primary"
+            size="lg"
+            flex={2}
+            disabled={submit.isPending}
+            opacity={submit.isPending ? 0.4 : 1}
+            onPress={handleSubmit}
+            testID="cm-entry-submit-btn"
+          >
+            {submit.isPending
+              ? formatUIText("submitting...")
+              : formatUIText("submit entry")}
+          </Button>
+        )}
+      </XStack>
+
+      {alert && (
+        <AlertModal
+          visible
+          title={alert.title}
+          message={alert.message}
+          onDismiss={() => {
+            const cb = alert.onConfirm;
+            setAlert(null);
+            cb?.();
+          }}
+          actions={[
+            {
+              label: "ok",
+              variant: "primary",
+              onPress: () => {
+                const cb = alert.onConfirm;
+                setAlert(null);
+                cb?.();
+              },
+            },
+          ]}
+        />
+      )}
+
+      {/* ── Player stats modal ──────────────────────────────────── */}
+      {statsPlayerId && (
+        <PlayerStatsModal
+          playerId={statsPlayerId}
+          onClose={() => setStatsPlayerId(null)}
+        />
+      )}
+
+      {/* ── NRR explainer modal ─────────────────────────────────── */}
+      <NrrExplainerModal visible={showExplainer} onClose={dismissExplainer} />
+
+      {/* Guru AI sheet — Rate My XI / Suggest orders / What If */}
+      {showGuru && roundId && (
+        <GuruSheet
+          roundId={roundId}
+          step={step}
+          eligibleById={byId}
+          onApplyBatting={(order: string[]) => {
+            // Filter to only ids in current squad — preserve user's actual picks
+            const inSquad = order.filter((id: string) =>
+              selectedIds.includes(id)
+            );
+            if (inSquad.length === selectedIds.length) {
+              setBattingOrder(inSquad);
+              setShowGuru(false);
+            }
+          }}
+          onApplyBowling={(order: string[]) => {
+            const inSquad = order.filter((id: string) =>
+              selectedIds.includes(id)
+            );
+            if (inSquad.length > 0) {
+              setBowlingPriority(inSquad);
+              setShowGuru(false);
+            }
+          }}
+          onClose={() => setShowGuru(false)}
+        />
+      )}
+
+      <Paywall {...paywallProps} />
+    </YStack>
+  );
+}
+
+// ─── Guru AI sheet — Rate My XI, Suggest orders, What If ──────────────
+
+function GuruSheet({
+  roundId,
+  step,
+  eligibleById,
+  onApplyBatting,
+  onApplyBowling,
+  onClose,
+}: {
+  roundId: string;
+  step: Step;
+  eligibleById: Map<string, EligiblePlayer>;
+  onApplyBatting: (order: string[]) => void;
+  onApplyBowling: (order: string[]) => void;
+  onClose: () => void;
+}) {
+  const rateQuery = trpc.cricketManager.rateMyXi.useQuery({ roundId });
+  const battingQuery = trpc.cricketManager.suggestBattingOrder.useQuery(
+    { roundId },
+    { enabled: step !== "review" }
+  );
+  const bowlingQuery = trpc.cricketManager.suggestBowlingOrder.useQuery(
+    { roundId },
+    { enabled: step !== "review" }
+  );
+  const whatIfQuery = trpc.cricketManager.whatIf.useQuery(
+    { roundId },
+    { enabled: step === "review" }
+  );
+
+  return (
+    <YStack
+      position="absolute"
+      top={0}
+      left={0}
+      right={0}
+      bottom={0}
+      zIndex={250}
+      backgroundColor="rgba(0,0,0,0.6)"
+      alignItems="center"
+      justifyContent="center"
+      padding="$4"
+    >
+      <Pressable
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+        }}
+        onPress={onClose}
+      />
+      <YStack
+        width="100%"
+        maxWidth={420}
+        maxHeight="92%"
+        backgroundColor="$backgroundSurface"
+        borderRadius={20}
+        borderWidth={1}
+        borderColor="$borderColor"
+        overflow="hidden"
+      >
+        <ScrollView contentContainerStyle={{ padding: 20 }}>
+          {/* Header */}
+          <XStack alignItems="center" gap="$2" marginBottom="$3">
+            <Text fontSize={22}>✨</Text>
+            <Text
+              fontFamily="$mono"
+              fontWeight="700"
+              fontSize={18}
+              color="$color"
+              letterSpacing={-0.5}
+            >
+              {formatUIText("guru analysis")}
+            </Text>
+          </XStack>
+
+          {/* Rate My XI — always shown */}
+          {rateQuery.isLoading ? (
+            <YStack padding="$4" alignItems="center">
+              <EggLoadingSpinner size={32} />
+            </YStack>
+          ) : rateQuery.data ? (
+            <YStack
+              padding="$4"
+              backgroundColor="$backgroundSurfaceAlt"
+              borderRadius={12}
+              marginBottom="$3"
+            >
+              <XStack
+                justifyContent="space-between"
+                alignItems="center"
+                marginBottom="$2"
+              >
+                <Text
+                  fontFamily="$mono"
+                  fontSize={10}
+                  color="$colorMuted"
+                  textTransform="uppercase"
+                  letterSpacing={1}
+                >
+                  {formatUIText("rate my xi")}
+                </Text>
+                <YStack
+                  width={44}
+                  height={44}
+                  borderRadius={22}
+                  backgroundColor="$accentBackground"
+                  alignItems="center"
+                  justifyContent="center"
+                >
+                  <Text
+                    fontFamily="$mono"
+                    fontWeight="800"
+                    fontSize={16}
+                    color="$background"
+                  >
+                    {rateQuery.data.grade}
+                  </Text>
+                </YStack>
+              </XStack>
+              <Text
+                fontFamily="$body"
+                fontWeight="700"
+                fontSize={14}
+                color="$color"
+              >
+                {rateQuery.data.headline}
+              </Text>
+              <Text
+                fontFamily="$mono"
+                fontSize={10}
+                color="$colorMuted"
+                marginTop="$1"
+              >
+                score {rateQuery.data.score}/100
+              </Text>
+
+              {rateQuery.data.strengths.length > 0 && (
+                <YStack marginTop="$3">
+                  <Text
+                    fontFamily="$mono"
+                    fontSize={9}
+                    color="$accentBackground"
+                    fontWeight="700"
+                    textTransform="uppercase"
+                    letterSpacing={1}
+                  >
+                    {formatUIText("strengths")}
+                  </Text>
+                  {rateQuery.data.strengths.map((s: string, i: number) => (
+                    <XStack key={i} gap="$2" marginTop={4} alignItems="flex-start">
+                      <Text fontSize={10} color="$accentBackground">
+                        ✓
+                      </Text>
+                      <Text
+                        fontFamily="$body"
+                        fontSize={11}
+                        color="$color"
+                        flex={1}
+                        lineHeight={15}
+                      >
+                        {s}
+                      </Text>
+                    </XStack>
+                  ))}
+                </YStack>
+              )}
+
+              {rateQuery.data.weaknesses.length > 0 && (
+                <YStack marginTop="$3">
+                  <Text
+                    fontFamily="$mono"
+                    fontSize={9}
+                    color="$colorHatch"
+                    fontWeight="700"
+                    textTransform="uppercase"
+                    letterSpacing={1}
+                  >
+                    {formatUIText("weaknesses")}
+                  </Text>
+                  {rateQuery.data.weaknesses.map((s: string, i: number) => (
+                    <XStack key={i} gap="$2" marginTop={4} alignItems="flex-start">
+                      <Text fontSize={10} color="$colorHatch">
+                        !
+                      </Text>
+                      <Text
+                        fontFamily="$body"
+                        fontSize={11}
+                        color="$color"
+                        flex={1}
+                        lineHeight={15}
+                      >
+                        {s}
+                      </Text>
+                    </XStack>
+                  ))}
+                </YStack>
+              )}
+
+              {rateQuery.data.suggestions.length > 0 && (
+                <YStack marginTop="$3">
+                  <Text
+                    fontFamily="$mono"
+                    fontSize={9}
+                    color="$colorCricket"
+                    fontWeight="700"
+                    textTransform="uppercase"
+                    letterSpacing={1}
+                  >
+                    {formatUIText("suggestions")}
+                  </Text>
+                  {rateQuery.data.suggestions.map((s: string, i: number) => (
+                    <Text
+                      key={i}
+                      fontFamily="$body"
+                      fontSize={11}
+                      color="$colorMuted"
+                      marginTop={4}
+                      lineHeight={15}
+                    >
+                      → {s}
+                    </Text>
+                  ))}
+                </YStack>
+              )}
+            </YStack>
+          ) : null}
+
+          {/* Suggest batting order */}
+          {step === "batting" && battingQuery.data && (
+            <SuggestionBlock
+              title="suggested batting order"
+              accent="$accentBackground"
+              suggestions={battingQuery.data}
+              eligibleById={eligibleById}
+              onApply={() =>
+                onApplyBatting(
+                  battingQuery.data!.map(
+                    (s: { playerId: string }) => s.playerId
+                  )
+                )
+              }
+            />
+          )}
+
+          {/* Suggest bowling order */}
+          {step === "bowling" && bowlingQuery.data && (
+            <SuggestionBlock
+              title="suggested bowling order"
+              accent="$colorCricket"
+              suggestions={bowlingQuery.data}
+              eligibleById={eligibleById}
+              onApply={() =>
+                onApplyBowling(
+                  bowlingQuery.data!.map(
+                    (s: { playerId: string }) => s.playerId
+                  )
+                )
+              }
+            />
+          )}
+
+          {/* What If — review step */}
+          {step === "review" && whatIfQuery.data && (
+            <YStack
+              padding="$4"
+              backgroundColor="$backgroundSurfaceAlt"
+              borderRadius={12}
+              marginBottom="$3"
+            >
+              <Text
+                fontFamily="$mono"
+                fontSize={10}
+                color="$colorMuted"
+                textTransform="uppercase"
+                letterSpacing={1}
+                marginBottom="$2"
+              >
+                {formatUIText("what if")}
+              </Text>
+              <XStack
+                justifyContent="space-between"
+                alignItems="baseline"
+                marginBottom="$2"
+              >
+                <Text fontFamily="$body" fontSize={11} color="$colorMuted">
+                  your top-7 projected
+                </Text>
+                <Text
+                  fontFamily="$mono"
+                  fontWeight="700"
+                  fontSize={14}
+                  color="$color"
+                >
+                  {whatIfQuery.data.actualEstimate} pts
+                </Text>
+              </XStack>
+              <XStack
+                justifyContent="space-between"
+                alignItems="baseline"
+                marginBottom="$2"
+              >
+                <Text fontFamily="$body" fontSize={11} color="$colorMuted">
+                  guru's top-7 projected
+                </Text>
+                <Text
+                  fontFamily="$mono"
+                  fontWeight="700"
+                  fontSize={14}
+                  color="$accentBackground"
+                >
+                  {whatIfQuery.data.suggestedEstimate} pts
+                </Text>
+              </XStack>
+              <YStack
+                marginTop="$2"
+                paddingTop="$2"
+                borderTopWidth={1}
+                borderTopColor="$borderColor"
+              >
+                <Text
+                  fontFamily="$mono"
+                  fontWeight="800"
+                  fontSize={16}
+                  color={
+                    whatIfQuery.data.deltaPoints > 0
+                      ? "$colorCricket"
+                      : "$accentBackground"
+                  }
+                  textAlign="center"
+                >
+                  {whatIfQuery.data.deltaPoints > 0
+                    ? `you could gain +${whatIfQuery.data.deltaPoints} pts`
+                    : whatIfQuery.data.deltaPoints < 0
+                      ? "your order is already optimal"
+                      : "tied with guru's order"}
+                </Text>
+              </YStack>
+            </YStack>
+          )}
+
+          <Button variant="secondary" size="md" onPress={onClose}>
+            {formatUIText("close")}
+          </Button>
+        </ScrollView>
+      </YStack>
+    </YStack>
+  );
+}
+
+function SuggestionBlock({
+  title,
+  accent,
+  suggestions,
+  eligibleById,
+  onApply,
+}: {
+  title: string;
+  accent: "$accentBackground" | "$colorCricket";
+  suggestions: Array<{
+    playerId: string;
+    suggestedPosition: number;
+    reason: string;
+  }>;
+  eligibleById: Map<string, EligiblePlayer>;
+  onApply: () => void;
+}) {
+  return (
+    <YStack
+      padding="$4"
+      backgroundColor="$backgroundSurfaceAlt"
+      borderRadius={12}
+      marginBottom="$3"
+    >
+      <Text
+        fontFamily="$mono"
+        fontSize={10}
+        color="$colorMuted"
+        textTransform="uppercase"
+        letterSpacing={1}
+        marginBottom="$3"
+      >
+        {formatUIText(title)}
+      </Text>
+      {suggestions.slice(0, 7).map((s, i) => {
+        const p = eligibleById.get(s.playerId);
+        if (!p) return null;
+        return (
+          <XStack
+            key={s.playerId}
+            alignItems="center"
+            gap="$2"
+            paddingVertical={6}
+            borderBottomWidth={i < Math.min(6, suggestions.length - 1) ? 1 : 0}
+            borderBottomColor="$borderColor"
+          >
+            <Text
+              fontFamily="$mono"
+              fontWeight="800"
+              fontSize={13}
+              color={accent}
+              width={20}
+            >
+              {s.suggestedPosition}
+            </Text>
+            <YStack flex={1}>
+              <Text
+                fontFamily="$body"
+                fontWeight="700"
+                fontSize={12}
+                color="$color"
+                numberOfLines={1}
+              >
+                {p.name}
+              </Text>
+              <Text
+                fontFamily="$body"
+                fontSize={9}
+                color="$colorMuted"
+                numberOfLines={1}
+              >
+                {s.reason}
+              </Text>
+            </YStack>
+          </XStack>
+        );
+      })}
+      <Button
+        variant="primary"
+        size="sm"
+        marginTop="$3"
+        onPress={onApply}
+      >
+        {formatUIText("apply this order")}
+      </Button>
+    </YStack>
+  );
+}
+
+// ─── Player stats modal — reused from auction draft pattern ────────────
+
+function PlayerStatsModal({
+  playerId,
+  onClose,
+}: {
+  playerId: string;
+  onClose: () => void;
+}) {
+  const { data, isLoading } = trpc.auctionAi.playerStats.useQuery(
+    { playerId },
+    { staleTime: 60 * 60_000 }
+  );
+
+  return (
+    <YStack
+      position="absolute"
+      top={0}
+      left={0}
+      right={0}
+      bottom={0}
+      zIndex={200}
+      alignItems="center"
+      justifyContent="center"
+      backgroundColor="rgba(0,0,0,0.55)"
+    >
+      <Pressable
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+        }}
+        onPress={onClose}
+      />
+      <YStack
+        backgroundColor="$backgroundSurface"
+        borderRadius={20}
+        padding="$5"
+        width="88%"
+        maxWidth={360}
+        borderWidth={1}
+        borderColor="$borderColor"
+      >
+        {isLoading || !data ? (
+          <YStack alignItems="center" padding="$4">
+            <EggLoadingSpinner size={32} />
+          </YStack>
+        ) : (
+          <>
+            {/* Header */}
+            <XStack
+              justifyContent="space-between"
+              alignItems="flex-start"
+              marginBottom="$3"
+            >
+              <YStack flex={1}>
+                <Text
+                  fontFamily="$body"
+                  fontWeight="700"
+                  fontSize={18}
+                  color="$color"
+                >
+                  {data.name}
+                </Text>
+                <XStack alignItems="center" gap="$2" marginTop={2} flexWrap="wrap">
+                  <Badge variant="default" size="sm">
+                    {roleToBadge(data.role ?? "batsman")}
+                  </Badge>
+                  <Text fontFamily="$mono" fontSize={10} color="$colorMuted">
+                    {data.team}
+                  </Text>
+                  {data.nationality && (
+                    <Text fontFamily="$mono" fontSize={10} color="$colorMuted">
+                      {data.nationality}
+                    </Text>
+                  )}
+                </XStack>
+              </YStack>
+            </XStack>
+
+            {/* Primary stats grid */}
+            {(data.matchesPlayed != null ||
+              (data.average != null && data.average > 0) ||
+              (data.strikeRate != null && data.strikeRate > 0)) && (
+              <XStack marginBottom="$3" gap="$2">
+                {data.matchesPlayed != null && (
+                  <StatCell label="MATCHES" value={String(data.matchesPlayed)} />
+                )}
+                {data.average != null && data.average > 0 && (
+                  <StatCell label="AVG" value={data.average.toFixed(1)} />
+                )}
+                {data.strikeRate != null && data.strikeRate > 0 && (
+                  <StatCell label="SR" value={data.strikeRate.toFixed(0)} />
+                )}
+              </XStack>
+            )}
+
+            {/* Bowling stats (conditional) */}
+            {(data.economyRate ?? 0) > 0 && (
+              <XStack marginBottom="$3" gap="$2">
+                <StatCell label="ECON" value={(data.economyRate ?? 0).toFixed(1)} />
+                {data.bowlingAverage != null && data.bowlingAverage > 0 && (
+                  <StatCell
+                    label="B.AVG"
+                    value={data.bowlingAverage.toFixed(1)}
+                  />
+                )}
+                {data.bowlingStrikeRate != null && data.bowlingStrikeRate > 0 && (
+                  <StatCell
+                    label="B.SR"
+                    value={data.bowlingStrikeRate.toFixed(0)}
+                  />
+                )}
+              </XStack>
+            )}
+
+            {/* Form + injury status */}
+            {(data.recentForm != null || data.injuryStatus) && (
+              <XStack
+                gap="$3"
+                alignItems="center"
+                marginBottom={data.formNote ? "$2" : 0}
+              >
+                {data.recentForm != null && (
+                  <XStack alignItems="center" gap="$1">
+                    <Text fontFamily="$mono" fontSize={9} color="$colorMuted">
+                      FORM
+                    </Text>
+                    <Text
+                      fontFamily="$mono"
+                      fontWeight="700"
+                      fontSize={14}
+                      color={
+                        data.recentForm >= 7
+                          ? "$accentBackground"
+                          : data.recentForm >= 4
+                          ? "$colorCricket"
+                          : "$colorHatch"
+                      }
+                    >
+                      {data.recentForm}/10
+                    </Text>
+                  </XStack>
+                )}
+                {data.injuryStatus && data.injuryStatus !== "fit" && (
+                  <Badge variant="danger" size="sm">
+                    {data.injuryStatus.toUpperCase()}
+                  </Badge>
+                )}
+                {data.battingStyle && (
+                  <Text fontFamily="$mono" fontSize={9} color="$colorMuted">
+                    {data.battingStyle}
+                  </Text>
+                )}
+              </XStack>
+            )}
+
+            {data.formNote && (
+              <Text
+                fontFamily="$body"
+                fontSize={11}
+                color="$colorSecondary"
+                lineHeight={16}
+                marginTop="$2"
+              >
+                {data.formNote}
+              </Text>
+            )}
+
+            {/* Close button */}
+            <Button variant="secondary" size="sm" marginTop="$4" onPress={onClose}>
+              {formatUIText("close")}
+            </Button>
+          </>
+        )}
+      </YStack>
+    </YStack>
+  );
+}
+
+function StatCell({ label, value }: { label: string; value: string }) {
+  return (
+    <YStack
+      flex={1}
+      backgroundColor="$backgroundSurfaceAlt"
+      borderRadius={8}
+      padding="$2"
+      alignItems="center"
+    >
+      <Text fontFamily="$mono" fontSize={8} color="$colorMuted">
+        {label}
+      </Text>
+      <Text fontFamily="$mono" fontWeight="800" fontSize={18} color="$color">
+        {value}
+      </Text>
+    </YStack>
+  );
+}
+
+// ─── Sub-components ──────────────────────────────────────────────────
+
+function StepIndicator({ step }: { step: Step }) {
+  const steps: Array<{ key: Step; label: string }> = [
+    { key: "squad", label: "squad" },
+    { key: "batting", label: "batting" },
+    { key: "bowling", label: "bowling" },
+    { key: "review", label: "review" },
+  ];
+  const currentIdx = steps.findIndex((s) => s.key === step);
+  return (
+    <YStack paddingHorizontal="$4" paddingBottom="$3" gap="$2">
+      {/* Progress bar */}
+      <XStack gap="$1">
+        {steps.map((_, i) => {
+          const isDone = i < currentIdx;
+          const isActive = i === currentIdx;
+          return (
+            <YStack
+              key={i}
+              flex={1}
+              height={3}
+              borderRadius={2}
+              backgroundColor={
+                isDone || isActive ? "$accentBackground" : "$borderColor"
+              }
+            />
+          );
+        })}
+      </XStack>
+      {/* Labels row */}
+      <XStack>
+        {steps.map((s, i) => {
+          const isActive = i === currentIdx;
+          return (
+            <YStack key={s.key} flex={1} alignItems="center">
+              <Text
+                fontFamily="$mono"
+                fontSize={9}
+                fontWeight={isActive ? "700" : "500"}
+                color={isActive ? "$accentBackground" : "$colorMuted"}
+                textTransform="uppercase"
+                letterSpacing={0.6}
+              >
+                {s.label}
+              </Text>
+            </YStack>
+          );
+        })}
+      </XStack>
+    </YStack>
+  );
+}
+
+function OrderRow({
+  player,
+  position,
+  accentColor,
+  projected,
+  opponent,
+  onUp,
+  onDown,
+  upDisabled,
+  downDisabled,
+  readonly,
+}: {
+  player: EligiblePlayer;
+  position: number;
+  accentColor: "$accentBackground" | "$colorCricket";
+  projected?: number;
+  opponent?: string;
+  onUp?: () => void;
+  onDown?: () => void;
+  upDisabled?: boolean;
+  downDisabled?: boolean;
+  readonly?: boolean;
+}) {
+  return (
+    <Card
+      padding="$3"
+      marginBottom="$2"
+      borderWidth={1}
+      borderColor="$borderColor"
+      backgroundColor="$backgroundSurface"
+    >
+      <XStack alignItems="center" gap="$2">
+        {/* Position number */}
+        <YStack width={28} alignItems="center">
+          <Text
+            fontFamily="$mono"
+            fontWeight="800"
+            fontSize={16}
+            color={accentColor}
+          >
+            {position}
+          </Text>
+        </YStack>
+
+        {/* Avatar */}
+        <InitialsAvatar
+          name={player.name}
+          playerRole={roleToBadge(player.role)}
+          ovr={0}
+          size={36}
+          hideBadge
+          imageUrl={player.photoUrl ?? undefined}
+        />
+
+        {/* Name + team/role + opponent */}
+        <YStack flex={1} marginLeft="$2">
+          <Text {...textStyles.playerName} numberOfLines={1}>
+            {player.name}
+          </Text>
+          <XStack alignItems="center" gap={6}>
+            <Text
+              fontFamily="$mono"
+              fontSize={11}
+              color="$colorMuted"
+              numberOfLines={1}
+            >
+              {teamShortCode(player.team)} · {roleToBadge(player.role)}
+            </Text>
+            {opponent && (
+              <Text
+                fontFamily="$mono"
+                fontSize={11}
+                color="$accentBackground"
+                fontWeight="700"
+                numberOfLines={1}
+              >
+                vs {opponent}
+              </Text>
+            )}
+          </XStack>
+        </YStack>
+
+        {/* Projected pts — fixed width column so rows align whether data exists or not */}
+        <YStack alignItems="center" width={42} marginRight="$2">
+          {projected != null ? (
+            <>
+              <Text
+                fontFamily="$mono"
+                fontWeight="700"
+                fontSize={14}
+                color={accentColor}
+              >
+                {projected.toFixed(0)}
+              </Text>
+              <Text {...textStyles.hint}>pts</Text>
+            </>
+          ) : (
+            <Text fontFamily="$mono" fontSize={11} color="$colorMuted">
+              —
+            </Text>
+          )}
+        </YStack>
+
+        {/* Arrows — hidden in readonly (review) mode */}
+        {!readonly && (
+          <XStack gap="$1">
+            <Button
+              size="sm"
+              variant="secondary"
+              disabled={upDisabled}
+              onPress={onUp}
+            >
+              ↑
+            </Button>
+            <Button
+              size="sm"
+              variant="secondary"
+              disabled={downDisabled}
+              onPress={onDown}
+            >
+              ↓
+            </Button>
+          </XStack>
+        )}
+      </XStack>
+    </Card>
+  );
+}
+
+function SmartPill({
+  emoji,
+  label,
+  active,
+  onPress,
+}: {
+  emoji: string;
+  label: string;
+  active: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable onPress={onPress}>
+      <XStack
+        paddingHorizontal={10}
+        paddingVertical={5}
+        borderRadius={14}
+        borderWidth={1}
+        borderColor={active ? "$color" : "$borderColor"}
+        backgroundColor={active ? "$color" : "$backgroundSurface"}
+        alignItems="center"
+        gap={4}
+      >
+        <Text fontSize={10}>{emoji}</Text>
+        <Text
+          fontFamily="$mono"
+          fontSize={9}
+          fontWeight="700"
+          color={active ? "$background" : "$colorMuted"}
+        >
+          {formatBadgeText(label)}
+        </Text>
+      </XStack>
+    </Pressable>
+  );
+}
+
+// ─── ScenarioBar — reusable bar-graph row for scenario preview ──────────
+function ScenarioBar({
+  label,
+  value,
+  max,
+  color,
+  capped,
+}: {
+  label: string;
+  value: number;
+  max: number;
+  color: "$accentBackground" | "$colorCricket";
+  capped?: boolean;
+}) {
+  const pct = Math.max(0, Math.min(100, Math.round((value / max) * 100)));
+  return (
+    <YStack gap={2}>
+      <XStack justifyContent="space-between" alignItems="baseline">
+        <Text fontFamily="$body" fontSize={10} color="$colorMuted">
+          {label}
+          {capped ? " (capped)" : ""}
+        </Text>
+        <Text
+          fontFamily="$mono"
+          fontWeight="800"
+          fontSize={14}
+          color={color}
+        >
+          {value}
+        </Text>
+      </XStack>
+      <YStack
+        height={8}
+        borderRadius={4}
+        backgroundColor="$backgroundSurfaceAlt"
+        overflow="hidden"
+      >
+        <YStack
+          width={(`${pct}%` as unknown) as number}
+          height={8}
+          borderRadius={4}
+          backgroundColor={color}
+        />
+      </YStack>
+    </YStack>
+  );
+}
+
+// ─── NrrExplainerModal — simple, mobile-responsive how-it-works overlay ─
+function NrrExplainerModal({
+  visible,
+  onClose,
+}: {
+  visible: boolean;
+  onClose: () => void;
+}) {
+  if (!visible) return null;
+  return (
+    <YStack
+      position="absolute"
+      top={0}
+      left={0}
+      right={0}
+      bottom={0}
+      zIndex={300}
+      backgroundColor="rgba(0,0,0,0.6)"
+      alignItems="center"
+      justifyContent="center"
+      padding="$4"
+    >
+      <Pressable
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+        }}
+        onPress={onClose}
+      />
+      <YStack
+        width="100%"
+        maxWidth={420}
+        maxHeight="92%"
+        backgroundColor="$backgroundSurface"
+        borderRadius={20}
+        borderWidth={1}
+        borderColor="$borderColor"
+        overflow="hidden"
+      >
+        <ScrollView contentContainerStyle={{ padding: 20 }}>
+          {/* Title */}
+          <Text
+            fontFamily="$mono"
+            fontWeight="700"
+            fontSize={20}
+            color="$color"
+            letterSpacing={-0.5}
+            marginBottom="$1"
+          >
+            {formatUIText("how you win")}
+          </Text>
+          <Text
+            fontFamily="$body"
+            fontSize={12}
+            color="$colorMuted"
+            marginBottom="$4"
+            lineHeight={17}
+          >
+            {formatUIText(
+              "your 11 players play a mini cricket match against themselves. we calculate your NRR — higher wins the round."
+            )}
+          </Text>
+
+          {/* Step 1 — batting */}
+          <YStack
+            padding="$4"
+            backgroundColor="$backgroundSurfaceAlt"
+            borderRadius={12}
+            marginBottom="$3"
+          >
+            <XStack alignItems="center" gap="$2" marginBottom="$2">
+              <YStack
+                width={24}
+                height={24}
+                borderRadius={12}
+                backgroundColor="$accentBackground"
+                alignItems="center"
+                justifyContent="center"
+              >
+                <Text
+                  fontFamily="$mono"
+                  fontWeight="800"
+                  fontSize={12}
+                  color="$background"
+                >
+                  1
+                </Text>
+              </YStack>
+              <Text
+                fontFamily="$body"
+                fontWeight="700"
+                fontSize={14}
+                color="$color"
+              >
+                {formatUIText("your batters bat")}
+              </Text>
+            </XStack>
+            <Text
+              fontFamily="$body"
+              fontSize={11}
+              color="$colorMuted"
+              lineHeight={15}
+              marginBottom="$2"
+            >
+              {formatUIText(
+                "your batting order plays until 120 balls are used or 10 wickets fall. runs scored in real matches become your batting total."
+              )}
+            </Text>
+            <XStack
+              padding="$2"
+              backgroundColor="$background"
+              borderRadius={6}
+              alignItems="center"
+              gap="$2"
+            >
+              <Text fontFamily="$mono" fontSize={10} color="$colorMuted">
+                {formatUIText("example")}
+              </Text>
+              <Text
+                fontFamily="$mono"
+                fontWeight="700"
+                fontSize={12}
+                color="$accentBackground"
+              >
+                190 runs
+              </Text>
+            </XStack>
+          </YStack>
+
+          {/* Step 2 — bowling */}
+          <YStack
+            padding="$4"
+            backgroundColor="$backgroundSurfaceAlt"
+            borderRadius={12}
+            marginBottom="$3"
+          >
+            <XStack alignItems="center" gap="$2" marginBottom="$2">
+              <YStack
+                width={24}
+                height={24}
+                borderRadius={12}
+                backgroundColor="$colorCricket"
+                alignItems="center"
+                justifyContent="center"
+              >
+                <Text
+                  fontFamily="$mono"
+                  fontWeight="800"
+                  fontSize={12}
+                  color="$background"
+                >
+                  2
+                </Text>
+              </YStack>
+              <Text
+                fontFamily="$body"
+                fontWeight="700"
+                fontSize={14}
+                color="$color"
+              >
+                {formatUIText("your bowlers bowl")}
+              </Text>
+            </XStack>
+            <Text
+              fontFamily="$body"
+              fontSize={11}
+              color="$colorMuted"
+              lineHeight={15}
+              marginBottom="$2"
+            >
+              {formatUIText(
+                "your bowling order takes over — each bowler capped at 4 overs. runs they concede in real matches become your bowling total."
+              )}
+            </Text>
+            <XStack
+              padding="$2"
+              backgroundColor="$background"
+              borderRadius={6}
+              alignItems="center"
+              gap="$2"
+            >
+              <Text fontFamily="$mono" fontSize={10} color="$colorMuted">
+                {formatUIText("example")}
+              </Text>
+              <Text
+                fontFamily="$mono"
+                fontWeight="700"
+                fontSize={12}
+                color="$colorCricket"
+              >
+                136 runs conceded
+              </Text>
+            </XStack>
+          </YStack>
+
+          {/* Step 3 — NRR */}
+          <YStack
+            padding="$4"
+            backgroundColor="$backgroundSurfaceAlt"
+            borderRadius={12}
+            marginBottom="$4"
+            borderWidth={1}
+            borderColor="$accentBackground"
+          >
+            <XStack alignItems="center" gap="$2" marginBottom="$2">
+              <YStack
+                width={24}
+                height={24}
+                borderRadius={12}
+                backgroundColor="$color"
+                alignItems="center"
+                justifyContent="center"
+              >
+                <Text
+                  fontFamily="$mono"
+                  fontWeight="800"
+                  fontSize={12}
+                  color="$background"
+                >
+                  3
+                </Text>
+              </YStack>
+              <Text
+                fontFamily="$body"
+                fontWeight="700"
+                fontSize={14}
+                color="$color"
+              >
+                {formatUIText("we calculate NRR")}
+              </Text>
+            </XStack>
+            <Text
+              fontFamily="$body"
+              fontSize={11}
+              color="$colorMuted"
+              lineHeight={15}
+              marginBottom="$3"
+            >
+              {formatUIText(
+                "net run rate = your run rate minus their run rate. divide both totals by 20 overs."
+              )}
+            </Text>
+            <YStack
+              padding="$3"
+              backgroundColor="$background"
+              borderRadius={8}
+              gap={4}
+            >
+              <XStack justifyContent="space-between" alignItems="center">
+                <Text fontFamily="$mono" fontSize={10} color="$colorMuted">
+                  190 ÷ 20
+                </Text>
+                <Text
+                  fontFamily="$mono"
+                  fontWeight="700"
+                  fontSize={13}
+                  color="$accentBackground"
+                >
+                  = 9.50
+                </Text>
+              </XStack>
+              <XStack justifyContent="space-between" alignItems="center">
+                <Text fontFamily="$mono" fontSize={10} color="$colorMuted">
+                  136 ÷ 20
+                </Text>
+                <Text
+                  fontFamily="$mono"
+                  fontWeight="700"
+                  fontSize={13}
+                  color="$colorCricket"
+                >
+                  = 6.80
+                </Text>
+              </XStack>
+              <YStack
+                height={1}
+                backgroundColor="$borderColor"
+                marginVertical={4}
+              />
+              <XStack justifyContent="space-between" alignItems="center">
+                <Text
+                  fontFamily="$mono"
+                  fontWeight="700"
+                  fontSize={11}
+                  color="$color"
+                >
+                  9.50 − 6.80
+                </Text>
+                <Text
+                  fontFamily="$mono"
+                  fontWeight="800"
+                  fontSize={18}
+                  color="$accentBackground"
+                >
+                  NRR +2.70
+                </Text>
+              </XStack>
+            </YStack>
+          </YStack>
+
+          {/* Toss split */}
+          <Text
+            fontFamily="$mono"
+            fontSize={11}
+            color="$colorMuted"
+            textTransform="uppercase"
+            letterSpacing={1}
+            marginBottom="$2"
+          >
+            {formatUIText("bat first vs bowl first")}
+          </Text>
+          <Text
+            fontFamily="$body"
+            fontSize={11}
+            color="$color"
+            lineHeight={16}
+            marginBottom="$3"
+          >
+            {formatUIText(
+              "you also decide if your squad bats first or bowls first. this changes the math:"
+            )}
+          </Text>
+
+          <YStack gap="$2" marginBottom="$4">
+            <YStack
+              padding="$3"
+              backgroundColor="$backgroundSurfaceAlt"
+              borderRadius={10}
+              borderLeftWidth={3}
+              borderLeftColor="$accentBackground"
+            >
+              <XStack alignItems="center" gap="$2" marginBottom={2}>
+                <Text fontSize={14}>🏏</Text>
+                <Text
+                  fontFamily="$body"
+                  fontWeight="700"
+                  fontSize={12}
+                  color="$accentBackground"
+                >
+                  {formatUIText("bat first")}
+                </Text>
+              </XStack>
+              <Text
+                fontFamily="$body"
+                fontSize={10}
+                color="$colorMuted"
+                lineHeight={14}
+              >
+                {formatUIText(
+                  "your batters swing freely for the full 120 balls. aim: post the biggest total possible."
+                )}
+              </Text>
+            </YStack>
+
+            <YStack
+              padding="$3"
+              backgroundColor="$backgroundSurfaceAlt"
+              borderRadius={10}
+              borderLeftWidth={3}
+              borderLeftColor="$colorCricket"
+            >
+              <XStack alignItems="center" gap="$2" marginBottom={2}>
+                <Text fontSize={14}>🎯</Text>
+                <Text
+                  fontFamily="$body"
+                  fontWeight="700"
+                  fontSize={12}
+                  color="$colorCricket"
+                >
+                  {formatUIText("bowl first")}
+                </Text>
+              </XStack>
+              <Text
+                fontFamily="$body"
+                fontSize={10}
+                color="$colorMuted"
+                lineHeight={14}
+              >
+                {formatUIText(
+                  "your bowlers restrict them, then your batters chase the target. stops the moment you win — so strong bowling + modest batting can beat a bigger squad."
+                )}
+              </Text>
+            </YStack>
+          </YStack>
+
+          <Button variant="primary" size="lg" onPress={onClose}>
+            {formatUIText("got it, let's play")}
+          </Button>
+        </ScrollView>
+      </YStack>
+    </YStack>
+  );
+}

--- a/apps/mobile/app/league/[id]/round/[roundId]/index.tsx
+++ b/apps/mobile/app/league/[id]/round/[roundId]/index.tsx
@@ -1,0 +1,1002 @@
+import { SafeBackButton } from "../../../../../components/SafeBackButton";
+import { ScrollView } from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useMemo } from "react";
+import Animated, { FadeInDown } from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { YStack, XStack } from "tamagui";
+import { Text } from "../../../../../components/SportText";
+import {
+  Card,
+  Badge,
+  Button,
+  InitialsAvatar,
+  EggLoadingSpinner,
+  textStyles,
+  formatUIText,
+  formatBadgeText,
+  formatTeamName,
+} from "@draftplay/ui";
+import { trpc } from "../../../../../lib/trpc";
+import { HeaderControls } from "../../../../../components/HeaderControls";
+
+const STATUS_VARIANT: Record<
+  string,
+  "default" | "live" | "role" | "warning" | "danger" | "success"
+> = {
+  upcoming: "role",
+  open: "success",
+  locked: "role",
+  live: "live",
+  settled: "default",
+  void: "danger",
+};
+
+type RoleKey = "BAT" | "BOWL" | "AR" | "WK";
+
+function roleToBadge(role: string): RoleKey {
+  if (role === "bowler") return "BOWL";
+  if (role === "all_rounder") return "AR";
+  if (role === "wicket_keeper") return "WK";
+  return "BAT";
+}
+
+function formatDateTime(dt: string | Date) {
+  const d = new Date(dt);
+  return d.toLocaleString("en-IN", {
+    day: "numeric",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatTimeOnly(dt: string | Date) {
+  return new Date(dt).toLocaleTimeString("en-IN", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatCountdown(dt: string | Date) {
+  const ms = new Date(dt).getTime() - Date.now();
+  if (ms < 0) return "started";
+  const h = Math.floor(ms / 3600000);
+  const m = Math.floor((ms % 3600000) / 60000);
+  if (h >= 24) return `${Math.floor(h / 24)}d ${h % 24}h`;
+  if (h >= 1) return `${h}h ${m}m`;
+  return `${m}m`;
+}
+
+export default function RoundHubScreen() {
+  const { id: leagueId, roundId } = useLocalSearchParams<{
+    id: string;
+    roundId: string;
+  }>();
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+
+  const roundQuery = trpc.cricketManager.getRound.useQuery(
+    { roundId: roundId! },
+    { enabled: !!roundId, refetchInterval: 15000 }
+  );
+
+  // Normalize for per-player scorecard lookup
+  const eligibleById = useMemo(() => {
+    const pool = (roundQuery.data?.eligiblePlayers ?? []) as Array<{
+      playerId: string;
+      name: string;
+      team: string;
+      role: string;
+      photoUrl?: string | null;
+    }>;
+    return new Map(pool.map((p) => [p.playerId, p]));
+  }, [roundQuery.data?.eligiblePlayers]);
+
+  // Aggregate match state per team across ALL matches in the round — a
+  // single team can play multiple matches in one round (e.g. SRH vs PBKS +
+  // SRH vs RR), so we need a combined view rather than last-write-wins.
+  const teamMatchState = useMemo(() => {
+    const map = new Map<
+      string,
+      {
+        done: number;
+        live: number;
+        upcoming: number;
+        /** overall state label */
+        state: "done" | "live" | "partial" | "upcoming";
+      }
+    >();
+
+    const rows = (roundQuery.data?.matches ?? []) as Array<{
+      id: string;
+      status: string;
+      teamHome: string;
+      teamAway: string;
+    }>;
+
+    const bump = (team: string, status: string) => {
+      const cur = map.get(team) ?? {
+        done: 0,
+        live: 0,
+        upcoming: 0,
+        state: "upcoming" as const,
+      };
+      if (status === "completed" || status === "abandoned") cur.done += 1;
+      else if (status === "live") cur.live += 1;
+      else cur.upcoming += 1;
+      map.set(team, cur);
+    };
+
+    for (const m of rows) {
+      bump(m.teamHome, m.status);
+      bump(m.teamAway, m.status);
+    }
+
+    // Compute combined state per team
+    for (const [team, counts] of map.entries()) {
+      let state: "done" | "live" | "partial" | "upcoming";
+      if (counts.live > 0) state = "live";
+      else if (counts.done > 0 && counts.upcoming > 0) state = "partial";
+      else if (counts.done > 0 && counts.upcoming === 0) state = "done";
+      else state = "upcoming";
+      map.set(team, { ...counts, state });
+    }
+
+    return map;
+  }, [roundQuery.data?.matches]);
+
+  if (roundQuery.isLoading) {
+    return (
+      <YStack
+        flex={1}
+        backgroundColor="$background"
+        justifyContent="center"
+        alignItems="center"
+      >
+        <EggLoadingSpinner size={48} message="loading round" />
+      </YStack>
+    );
+  }
+
+  if (!roundQuery.data) {
+    return (
+      <YStack
+        flex={1}
+        backgroundColor="$background"
+        justifyContent="center"
+        alignItems="center"
+      >
+        <Text {...textStyles.hint}>{formatUIText("round not found")}</Text>
+      </YStack>
+    );
+  }
+
+  const round = roundQuery.data;
+  const hasEntry = !!round.myEntry;
+  // Round status is the single source of truth for whether entries are
+  // accepted. Backend transitions `open → live` the moment the first match
+  // in the round goes live.
+  const isOpen = round.status === "open" || round.status === "upcoming";
+
+  const cta = (() => {
+    if (isOpen) {
+      return {
+        label: hasEntry ? "edit entry" : "build entry",
+        disabled: false,
+        variant: "primary" as const,
+      };
+    }
+    if (round.status === "locked" || round.status === "live") {
+      return {
+        label: hasEntry ? "view live scorecard" : "view leaderboard",
+        disabled: false,
+        variant: "primary" as const,
+      };
+    }
+    if (round.status === "settled") {
+      return {
+        label: hasEntry ? "view final scorecard" : "view results",
+        disabled: false,
+        variant: "primary" as const,
+      };
+    }
+    return { label: "view", disabled: true, variant: "secondary" as const };
+  })();
+
+  function onCtaPress() {
+    if (!roundId || !leagueId) return;
+    if (isOpen) {
+      router.push(`/league/${leagueId}/round/${roundId}/build` as never);
+    } else {
+      router.push(`/league/${leagueId}/round/${roundId}/leaderboard` as never);
+    }
+  }
+
+  // Next upcoming match for header countdown. Only count matches whose
+  // start time is actually in the future — a match that was reset back
+  // to "upcoming" after its start time passed isn't "next".
+  const nowMs = Date.now();
+  const sortedMatches = [...((round.matches ?? []) as any[])].sort(
+    (a, b) =>
+      new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
+  );
+  const nextMatch = sortedMatches.find(
+    (m) =>
+      m.status === "upcoming" && new Date(m.startTime).getTime() > nowMs
+  );
+  const liveMatch = sortedMatches.find((m) => m.status === "live");
+  const firstMatch = sortedMatches[0];
+  const completedCount = round.matchesCompleted ?? 0;
+  const totalMatches = round.matchesTotal ?? (round.matches?.length ?? 0);
+
+  return (
+    <YStack flex={1} backgroundColor="$background">
+      <ScrollView
+        contentContainerStyle={{
+          padding: 16,
+          paddingTop: insets.top + 16,
+          paddingBottom: insets.bottom + 24,
+        }}
+      >
+        <XStack
+          justifyContent="space-between"
+          alignItems="center"
+          marginBottom="$4"
+        >
+          <XStack alignItems="center" gap="$3">
+            <SafeBackButton />
+            <Text
+              fontFamily="$mono"
+              fontWeight="500"
+              fontSize={17}
+              color="$color"
+              letterSpacing={-0.5}
+            >
+              {formatUIText("round")} {round.roundNumber}
+            </Text>
+          </XStack>
+          <HeaderControls />
+        </XStack>
+
+        {/* Round header */}
+        <Animated.View entering={FadeInDown.delay(40).springify()}>
+          <Card padding="$5" marginBottom="$4">
+            <XStack justifyContent="space-between" alignItems="flex-start">
+              <YStack flex={1}>
+                <Text
+                  fontFamily="$mono"
+                  fontWeight="500"
+                  fontSize={18}
+                  color="$color"
+                  letterSpacing={-0.5}
+                >
+                  {round.name}
+                </Text>
+                <Text
+                  fontFamily="$body"
+                  fontSize={12}
+                  color="$colorMuted"
+                  marginTop="$1"
+                >
+                  {totalMatches} {formatUIText("matches")} ·{" "}
+                  {formatDateTime(round.windowStart)}
+                </Text>
+              </YStack>
+              <Badge
+                variant={STATUS_VARIANT[round.status] ?? "default"}
+                size="sm"
+              >
+                {formatBadgeText(round.status)}
+              </Badge>
+            </XStack>
+
+            {/* Progress bar — only once some match action has happened */}
+            {totalMatches > 0 &&
+              (completedCount > 0 || liveMatch || round.status !== "open") && (
+                <YStack marginTop="$3" gap={4}>
+                  <XStack alignItems="center" justifyContent="space-between">
+                    <Text
+                      fontFamily="$mono"
+                      fontSize={11}
+                      color="$colorMuted"
+                    >
+                      {completedCount}/{totalMatches}{" "}
+                      {formatUIText("matches done")}
+                    </Text>
+                    {liveMatch ? (
+                      <Text
+                        fontFamily="$mono"
+                        fontSize={11}
+                        color="$colorCricket"
+                        fontWeight="700"
+                      >
+                        ● {formatUIText("live")}:{" "}
+                        {formatTeamName(liveMatch.teamHome)} {formatUIText("vs")}{" "}
+                        {formatTeamName(liveMatch.teamAway)}
+                      </Text>
+                    ) : nextMatch ? (
+                      <Text
+                        fontFamily="$mono"
+                        fontSize={11}
+                        color="$accentBackground"
+                        fontWeight="700"
+                      >
+                        {formatUIText("next in")}{" "}
+                        {formatCountdown(nextMatch.startTime)}
+                      </Text>
+                    ) : null}
+                  </XStack>
+                  <YStack
+                    height={6}
+                    borderRadius={3}
+                    backgroundColor="$backgroundSurfaceAlt"
+                    overflow="hidden"
+                  >
+                    <YStack
+                      width={
+                        (`${Math.round((completedCount / Math.max(1, totalMatches)) * 100)}%` as unknown) as number
+                      }
+                      height={6}
+                      backgroundColor="$accentBackground"
+                    />
+                  </YStack>
+                </YStack>
+              )}
+
+            <XStack gap="$2" marginTop="$3" flexWrap="wrap">
+              <Badge variant="role" size="sm">
+                {round.ballLimit} balls
+              </Badge>
+              <Badge variant="role" size="sm">
+                min {round.minBowlers} bowlers
+              </Badge>
+              <Badge variant="role" size="sm">
+                max {round.maxOversPerBowler} overs/bowler
+              </Badge>
+              {isOpen &&
+                (() => {
+                  // Show "entries close when X vs Y starts" or the time if soon
+                  if (!firstMatch) return null;
+                  const startMs = new Date(firstMatch.startTime).getTime();
+                  if (startMs > nowMs) {
+                    return (
+                      <Badge variant="warning" size="sm">
+                        closes {formatCountdown(firstMatch.startTime)}
+                      </Badge>
+                    );
+                  }
+                  // Start time already passed but match not yet live — just
+                  // say "closes at first match" without a clock.
+                  return (
+                    <Badge variant="warning" size="sm">
+                      closes at first match
+                    </Badge>
+                  );
+                })()}
+              {round.status === "live" && (
+                <Badge variant="live" size="sm">
+                  entries locked
+                </Badge>
+              )}
+            </XStack>
+          </Card>
+        </Animated.View>
+
+        {/* ── Live dual-bar race (if user has entry and round is live/settled) ── */}
+        {round.myEntry &&
+          (round.status === "live" ||
+            round.status === "locked" ||
+            round.status === "settled") && (
+            <Animated.View entering={FadeInDown.delay(100).springify()}>
+              <DualBarRace
+                batting={round.myEntry.battingTotal ?? 0}
+                bowling={round.myEntry.bowlingTotal ?? 0}
+                nrr={Number(round.myEntry.nrr ?? 0)}
+                isLive={round.status === "live"}
+              />
+            </Animated.View>
+          )}
+
+        {/* ── Per-player live scorecard ── */}
+        {round.myEntry &&
+          (round.status === "live" ||
+            round.status === "locked" ||
+            round.status === "settled") && (
+            <Animated.View entering={FadeInDown.delay(140).springify()}>
+              <PerPlayerScorecard
+                entry={round.myEntry}
+                eligibleById={eligibleById}
+                teamMatchState={teamMatchState}
+                roundSettled={round.status === "settled"}
+              />
+            </Animated.View>
+          )}
+
+        {/* Matches in this round */}
+        <Text
+          fontFamily="$mono"
+          fontSize={12}
+          color="$colorMuted"
+          textTransform="uppercase"
+          letterSpacing={1}
+          marginBottom="$2"
+          marginTop="$4"
+        >
+          {formatUIText("matches in round")}
+        </Text>
+        {sortedMatches.length === 0 ? (
+          <Card padding="$5" alignItems="center" marginBottom="$4">
+            <Text {...textStyles.hint}>{formatUIText("no matches")}</Text>
+          </Card>
+        ) : (
+          sortedMatches.map((m: any, i: number) => {
+            const isDone =
+              m.status === "completed" || m.status === "abandoned";
+            const isLive = m.status === "live";
+            return (
+              <Animated.View
+                key={m.id}
+                entering={FadeInDown.delay(180 + i * 30).springify()}
+              >
+                <Card
+                  marginBottom="$2"
+                  padding="$4"
+                  borderWidth={isLive ? 2 : 1}
+                  borderColor={isLive ? "$colorCricket" : "$borderColor"}
+                >
+                  <XStack
+                    justifyContent="space-between"
+                    alignItems="flex-start"
+                  >
+                    <YStack flex={1}>
+                      <Text
+                        fontFamily="$mono"
+                        fontWeight="600"
+                        fontSize={14}
+                        color="$accentBackground"
+                      >
+                        {formatTeamName(m.teamHome)} {formatUIText("vs")}{" "}
+                        {formatTeamName(m.teamAway)}
+                      </Text>
+                      <Text
+                        fontFamily="$body"
+                        fontSize={11}
+                        color="$colorMuted"
+                        marginTop="$1"
+                      >
+                        {m.format?.toUpperCase?.() ?? ""} ·{" "}
+                        {formatDateTime(m.startTime)}
+                      </Text>
+                      {m.venue && (
+                        <Text
+                          fontFamily="$body"
+                          fontSize={11}
+                          color="$colorMuted"
+                          numberOfLines={1}
+                        >
+                          {m.venue}
+                        </Text>
+                      )}
+                      {m.scoreSummary && (
+                        <Text
+                          fontFamily="$mono"
+                          fontSize={11}
+                          color="$colorCricket"
+                          marginTop="$1"
+                        >
+                          {m.scoreSummary}
+                        </Text>
+                      )}
+                    </YStack>
+                    <Badge
+                      variant={
+                        isLive
+                          ? "live"
+                          : isDone
+                            ? "default"
+                            : "role"
+                      }
+                      size="sm"
+                    >
+                      {isLive ? "LIVE" : formatBadgeText(m.status)}
+                    </Badge>
+                  </XStack>
+                </Card>
+              </Animated.View>
+            );
+          })
+        )}
+
+        {/* CTA */}
+        <YStack marginTop="$4" gap="$2">
+          <Button
+            variant={cta.variant}
+            size="lg"
+            disabled={cta.disabled}
+            onPress={onCtaPress}
+            testID="round-cta"
+          >
+            {formatUIText(cta.label)}
+          </Button>
+          {round.status !== "upcoming" && (
+            <Button
+              variant="secondary"
+              size="md"
+              onPress={() =>
+                router.push(
+                  `/league/${leagueId}/round/${roundId}/leaderboard` as never
+                )
+              }
+            >
+              {formatUIText("leaderboard")}
+            </Button>
+          )}
+        </YStack>
+      </ScrollView>
+    </YStack>
+  );
+}
+
+// ─── Dual bar race ─────────────────────────────────────────────────────
+
+function DualBarRace({
+  batting,
+  bowling,
+  nrr,
+  isLive,
+}: {
+  batting: number;
+  bowling: number;
+  nrr: number;
+  isLive: boolean;
+}) {
+  const max = Math.max(batting, bowling, 1);
+  const batPct = Math.round((batting / max) * 100);
+  const bowlPct = Math.round((bowling / max) * 100);
+  const leadsBy = batting - bowling;
+  const leader =
+    leadsBy > 0 ? "batting leads" : leadsBy < 0 ? "bowling leads" : "tied";
+
+  return (
+    <Card
+      padding="$4"
+      marginBottom="$4"
+      borderWidth={isLive ? 2 : 1}
+      borderColor={isLive ? "$colorCricket" : "$borderColor"}
+    >
+      <XStack justifyContent="space-between" alignItems="center" marginBottom="$3">
+        <Text
+          fontFamily="$mono"
+          fontSize={10}
+          color="$colorMuted"
+          textTransform="uppercase"
+          letterSpacing={1}
+        >
+          {formatUIText("your internal match")}
+        </Text>
+        {isLive && (
+          <XStack alignItems="center" gap="$1">
+            <YStack
+              width={6}
+              height={6}
+              borderRadius={3}
+              backgroundColor="$colorCricket"
+            />
+            <Text
+              fontFamily="$mono"
+              fontSize={10}
+              color="$colorCricket"
+              fontWeight="700"
+            >
+              {formatUIText("live")}
+            </Text>
+          </XStack>
+        )}
+      </XStack>
+
+      {/* Batting bar */}
+      <YStack marginBottom="$2">
+        <XStack justifyContent="space-between" alignItems="baseline">
+          <Text fontFamily="$body" fontSize={10} color="$colorMuted">
+            BAT
+          </Text>
+          <Text
+            fontFamily="$mono"
+            fontWeight="800"
+            fontSize={16}
+            color="$accentBackground"
+          >
+            {batting}
+          </Text>
+        </XStack>
+        <YStack
+          marginTop={2}
+          height={10}
+          borderRadius={5}
+          backgroundColor="$backgroundSurfaceAlt"
+          overflow="hidden"
+        >
+          <YStack
+            width={(`${batPct}%` as unknown) as number}
+            height={10}
+            backgroundColor="$accentBackground"
+          />
+        </YStack>
+      </YStack>
+
+      {/* Bowling bar */}
+      <YStack>
+        <XStack justifyContent="space-between" alignItems="baseline">
+          <Text fontFamily="$body" fontSize={10} color="$colorMuted">
+            BOWL
+          </Text>
+          <Text
+            fontFamily="$mono"
+            fontWeight="800"
+            fontSize={16}
+            color="$colorCricket"
+          >
+            {bowling}
+          </Text>
+        </XStack>
+        <YStack
+          marginTop={2}
+          height={10}
+          borderRadius={5}
+          backgroundColor="$backgroundSurfaceAlt"
+          overflow="hidden"
+        >
+          <YStack
+            width={(`${bowlPct}%` as unknown) as number}
+            height={10}
+            backgroundColor="$colorCricket"
+          />
+        </YStack>
+      </YStack>
+
+      {/* NRR + leader */}
+      <XStack
+        marginTop="$3"
+        padding="$2"
+        backgroundColor="$backgroundSurfaceAlt"
+        borderRadius={8}
+        justifyContent="space-between"
+        alignItems="center"
+      >
+        <Text fontFamily="$body" fontSize={11} color="$colorMuted">
+          {formatUIText(leader)}
+        </Text>
+        <Text
+          fontFamily="$mono"
+          fontWeight="800"
+          fontSize={18}
+          color={nrr >= 0 ? "$accentBackground" : "$colorHatch"}
+        >
+          NRR {nrr >= 0 ? "+" : ""}
+          {nrr.toFixed(2)}
+        </Text>
+      </XStack>
+    </Card>
+  );
+}
+
+// ─── Per-player scorecard ──────────────────────────────────────────────
+
+function PerPlayerScorecard({
+  entry,
+  eligibleById,
+  teamMatchState,
+  roundSettled,
+}: {
+  entry: any;
+  eligibleById: Map<
+    string,
+    {
+      playerId: string;
+      name: string;
+      team: string;
+      role: string;
+      photoUrl?: string | null;
+    }
+  >;
+  teamMatchState: Map<
+    string,
+    {
+      done: number;
+      live: number;
+      upcoming: number;
+      state: "done" | "live" | "partial" | "upcoming";
+    }
+  >;
+  roundSettled: boolean;
+}) {
+  const battingOrder = (
+    (entry.battingOrder ?? []) as Array<{ position: number; playerId: string }>
+  )
+    .slice()
+    .sort((a, b) => a.position - b.position);
+  const bowlingPriority = (
+    (entry.bowlingPriority ?? []) as Array<{
+      priority: number;
+      playerId: string;
+    }>
+  )
+    .slice()
+    .sort((a, b) => a.priority - b.priority);
+
+  // Batting details — per-batter breakdown produced by the engine
+  const battingDetails = new Map<
+    string,
+    {
+      runs: number;
+      ballsFaced: number;
+      dismissed: boolean;
+      status: "full" | "partial" | "didnt_bat";
+    }
+  >();
+  for (const d of (entry.battingDetails ?? []) as Array<{
+    playerId: string;
+    runs: number;
+    ballsFaced: number;
+    dismissed: boolean;
+    status: "full" | "partial" | "didnt_bat";
+  }>) {
+    battingDetails.set(d.playerId, d);
+  }
+
+  const bowlingDetails = new Map<
+    string,
+    {
+      cappedOvers: number;
+      runsConceded: number;
+      wickets: number;
+    }
+  >();
+  for (const d of (entry.bowlingDetails ?? []) as Array<{
+    playerId: string;
+    cappedOvers: number;
+    runsConceded: number;
+    wickets: number;
+  }>) {
+    bowlingDetails.set(d.playerId, d);
+  }
+
+  // Icon reflects the AGGREGATED state across all of a team's matches
+  // in the round. A team with 1 done + 1 upcoming is "partial" (⏱), not
+  // just the state of whichever match happened to be listed last.
+  function matchIcon(playerTeam: string): string {
+    const s = teamMatchState.get(playerTeam);
+    if (!s) return "⏳";
+    if (s.state === "live") return "🔴";
+    if (s.state === "done") return "✅";
+    if (s.state === "partial") return "⏱";
+    return "⏳";
+  }
+
+  // When a player's team still has matches to come, their stats are a
+  // running snapshot — label as "so far" instead of "out" to avoid
+  // implying finality.
+  function hasMoreToCome(playerTeam: string): boolean {
+    const s = teamMatchState.get(playerTeam);
+    return !!s && (s.live > 0 || s.upcoming > 0);
+  }
+
+  // Convert raw balls bowled to cricket notation overs (e.g. 41 balls → 6.5
+  // not 6.8). The engine writes cappedOvers per-bowler in cricket notation
+  // already, but the aggregate footer was using decimal math — this fixes it.
+  function ballsToCricketOvers(balls: number): number {
+    const full = Math.floor(balls / 6);
+    const partial = balls % 6;
+    return full + partial / 10;
+  }
+
+  return (
+    <Card padding="$4" marginBottom="$4">
+      <Text
+        fontFamily="$mono"
+        fontSize={10}
+        color="$colorMuted"
+        textTransform="uppercase"
+        letterSpacing={1}
+        marginBottom="$2"
+      >
+        {formatUIText("your batting scorecard")}
+      </Text>
+
+      {battingOrder.map((slot, i) => {
+        const p = eligibleById.get(slot.playerId);
+        if (!p) return null;
+        const d = battingDetails.get(slot.playerId);
+        const mi = matchIcon(p.team);
+
+        return (
+          <XStack
+            key={`bat-${slot.playerId}`}
+            paddingVertical={6}
+            alignItems="center"
+            gap="$2"
+            borderBottomWidth={i < battingOrder.length - 1 ? 1 : 0}
+            borderBottomColor="$borderColor"
+          >
+            <Text
+              fontFamily="$mono"
+              fontSize={11}
+              color="$colorMuted"
+              width={20}
+            >
+              {slot.position}
+            </Text>
+            <InitialsAvatar
+              name={p.name}
+              playerRole={roleToBadge(p.role)}
+              ovr={0}
+              size={28}
+              hideBadge
+              imageUrl={p.photoUrl ?? undefined}
+            />
+            <YStack flex={1} marginLeft="$1">
+              <Text fontFamily="$body" fontWeight="700" fontSize={12} color="$color" numberOfLines={1}>
+                {p.name}
+              </Text>
+              <Text fontFamily="$mono" fontSize={9} color="$colorMuted">
+                {p.team.split(" ").map((w) => w[0]).join("")}
+              </Text>
+            </YStack>
+            <YStack alignItems="flex-end" minWidth={90}>
+              {d && d.status !== "didnt_bat" ? (
+                <>
+                  <Text
+                    fontFamily="$mono"
+                    fontWeight="700"
+                    fontSize={13}
+                    color={d.dismissed ? "$color" : "$accentBackground"}
+                  >
+                    {d.runs}
+                    {!d.dismissed ? "*" : ""} ({d.ballsFaced})
+                  </Text>
+                  <Text fontFamily="$mono" fontSize={9} color="$colorMuted">
+                    {mi}{" "}
+                    {d.status === "partial"
+                      ? "partial"
+                      : hasMoreToCome(p.team)
+                        ? "so far"
+                        : d.dismissed
+                          ? "out"
+                          : "not out"}
+                  </Text>
+                </>
+              ) : hasMoreToCome(p.team) ? (
+                <Text fontFamily="$mono" fontSize={10} color="$colorMuted">
+                  {mi} {formatUIText("yet to bat")}
+                </Text>
+              ) : (
+                <Text fontFamily="$mono" fontSize={10} color="$colorMuted">
+                  {mi} {formatUIText("did not bat")}
+                </Text>
+              )}
+            </YStack>
+          </XStack>
+        );
+      })}
+
+      {/* Balls used total */}
+      <XStack
+        marginTop="$2"
+        paddingTop="$2"
+        borderTopWidth={1}
+        borderTopColor="$borderColor"
+        justifyContent="space-between"
+      >
+        <Text fontFamily="$mono" fontSize={10} color="$colorMuted">
+          {roundSettled ? "balls used" : "balls used so far"}
+        </Text>
+        <Text fontFamily="$mono" fontSize={10} color="$color" fontWeight="700">
+          {entry.battingBallsUsed ?? 0}/120
+          {!roundSettled && (entry.battingBallsUsed ?? 0) < 120
+            ? " · more to come"
+            : ""}
+        </Text>
+      </XStack>
+
+      {/* Bowling scorecard */}
+      <Text
+        fontFamily="$mono"
+        fontSize={10}
+        color="$colorMuted"
+        textTransform="uppercase"
+        letterSpacing={1}
+        marginTop="$4"
+        marginBottom="$2"
+      >
+        {formatUIText("your bowling figures")}
+      </Text>
+
+      {bowlingPriority.map((slot, i) => {
+        const p = eligibleById.get(slot.playerId);
+        if (!p) return null;
+        const d = bowlingDetails.get(slot.playerId);
+        const mi = matchIcon(p.team);
+
+        return (
+          <XStack
+            key={`bowl-${slot.playerId}`}
+            paddingVertical={6}
+            alignItems="center"
+            gap="$2"
+            borderBottomWidth={i < bowlingPriority.length - 1 ? 1 : 0}
+            borderBottomColor="$borderColor"
+          >
+            <Text
+              fontFamily="$mono"
+              fontSize={11}
+              color="$colorCricket"
+              width={20}
+            >
+              {slot.priority}
+            </Text>
+            <InitialsAvatar
+              name={p.name}
+              playerRole={roleToBadge(p.role)}
+              ovr={0}
+              size={28}
+              hideBadge
+              imageUrl={p.photoUrl ?? undefined}
+            />
+            <YStack flex={1} marginLeft="$1">
+              <Text fontFamily="$body" fontWeight="700" fontSize={12} color="$color" numberOfLines={1}>
+                {p.name}
+              </Text>
+              <Text fontFamily="$mono" fontSize={9} color="$colorMuted">
+                {p.team.split(" ").map((w) => w[0]).join("")}
+              </Text>
+            </YStack>
+            <YStack alignItems="flex-end" minWidth={90}>
+              {d && d.runsConceded > 0 ? (
+                <>
+                  <Text
+                    fontFamily="$mono"
+                    fontWeight="700"
+                    fontSize={13}
+                    color="$colorCricket"
+                  >
+                    {d.cappedOvers.toFixed(1)}-{d.runsConceded}-{d.wickets}
+                  </Text>
+                  <Text fontFamily="$mono" fontSize={9} color="$colorMuted">
+                    {mi} {hasMoreToCome(p.team) ? "so far" : "done"}
+                  </Text>
+                </>
+              ) : hasMoreToCome(p.team) ? (
+                <Text fontFamily="$mono" fontSize={10} color="$colorMuted">
+                  {mi} {formatUIText("yet to bowl")}
+                </Text>
+              ) : (
+                <Text fontFamily="$mono" fontSize={10} color="$colorMuted">
+                  {mi} {formatUIText("did not bowl")}
+                </Text>
+              )}
+            </YStack>
+          </XStack>
+        );
+      })}
+
+      <XStack
+        marginTop="$2"
+        paddingTop="$2"
+        borderTopWidth={1}
+        borderTopColor="$borderColor"
+        justifyContent="space-between"
+      >
+        <Text fontFamily="$mono" fontSize={10} color="$colorMuted">
+          {roundSettled ? "overs bowled" : "overs bowled so far"}
+        </Text>
+        <Text fontFamily="$mono" fontSize={10} color="$color" fontWeight="700">
+          {ballsToCricketOvers(entry.bowlingBallsBowled ?? 0).toFixed(1)}/20.0
+          {!roundSettled && (entry.bowlingBallsBowled ?? 0) < 120
+            ? " · more to come"
+            : ""}
+        </Text>
+      </XStack>
+    </Card>
+  );
+}

--- a/apps/mobile/app/league/[id]/round/[roundId]/leaderboard.tsx
+++ b/apps/mobile/app/league/[id]/round/[roundId]/leaderboard.tsx
@@ -1,0 +1,284 @@
+import { SafeBackButton } from "../../../../../components/SafeBackButton";
+import { FlatList, Pressable } from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useEffect, useRef, useState } from "react";
+import Animated, { FadeInDown } from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { YStack, XStack } from "tamagui";
+import { Text } from "../../../../../components/SportText";
+import {
+  Card,
+  Badge,
+  InitialsAvatar,
+  EggLoadingSpinner,
+  textStyles,
+  formatUIText,
+} from "@draftplay/ui";
+import { trpc } from "../../../../../lib/trpc";
+import { useAuth } from "../../../../../providers/AuthProvider";
+import { HeaderControls } from "../../../../../components/HeaderControls";
+
+export default function RoundLeaderboardScreen() {
+  const { id: leagueId, roundId } = useLocalSearchParams<{
+    id: string;
+    roundId: string;
+  }>();
+  const insets = useSafeAreaInsets();
+  const { user } = useAuth();
+  const router = useRouter();
+
+  const roundQuery = trpc.cricketManager.getRound.useQuery(
+    { roundId: roundId! },
+    { enabled: !!roundId }
+  );
+  const leaderboardQuery = trpc.cricketManager.getRoundLeaderboard.useQuery(
+    { roundId: roundId!, limit: 200, offset: 0 },
+    { enabled: !!roundId, refetchInterval: 10000 }
+  );
+
+  // Track rank movement across refetches
+  const prevRanksRef = useRef<Map<string, number>>(new Map());
+  const [rankDeltas, setRankDeltas] = useState<Map<string, number>>(
+    new Map()
+  );
+
+  useEffect(() => {
+    const rows = leaderboardQuery.data?.rows ?? [];
+    const nextDeltas = new Map<string, number>();
+    const nextRanks = new Map<string, number>();
+    for (let i = 0; i < rows.length; i++) {
+      const r = rows[i] as any;
+      const currentRank = r.rank ?? i + 1;
+      nextRanks.set(r.userId, currentRank);
+      const prev = prevRanksRef.current.get(r.userId);
+      if (prev != null) {
+        // Positive = moved up (prev was larger), negative = moved down
+        nextDeltas.set(r.userId, prev - currentRank);
+      }
+    }
+    prevRanksRef.current = nextRanks;
+    setRankDeltas(nextDeltas);
+  }, [leaderboardQuery.data?.rows]);
+
+  if (roundQuery.isLoading || leaderboardQuery.isLoading) {
+    return (
+      <YStack
+        flex={1}
+        backgroundColor="$background"
+        justifyContent="center"
+        alignItems="center"
+      >
+        <EggLoadingSpinner size={48} message="loading" />
+      </YStack>
+    );
+  }
+
+  const round = roundQuery.data;
+  const rows = leaderboardQuery.data?.rows ?? [];
+  const isSettled = round?.status === "settled";
+
+  return (
+    <YStack flex={1} backgroundColor="$background">
+      <FlatList
+        data={rows}
+        keyExtractor={(item: any) => item.userId}
+        contentContainerStyle={{
+          padding: 16,
+          paddingTop: insets.top + 16,
+          paddingBottom: insets.bottom + 24,
+        }}
+        ListHeaderComponent={
+          <>
+            <XStack
+              justifyContent="space-between"
+              alignItems="center"
+              marginBottom="$4"
+            >
+              <XStack alignItems="center" gap="$3">
+                <SafeBackButton />
+                <Text
+                  fontFamily="$mono"
+                  fontWeight="500"
+                  fontSize={17}
+                  color="$color"
+                  letterSpacing={-0.5}
+                >
+                  {formatUIText("round leaderboard")}
+                </Text>
+              </XStack>
+              <HeaderControls />
+            </XStack>
+
+            {round && (
+              <Card padding="$4" marginBottom="$4">
+                <Text
+                  fontFamily="$mono"
+                  fontWeight="600"
+                  fontSize={14}
+                  color="$accentBackground"
+                >
+                  {round.name}
+                </Text>
+                <Text
+                  fontFamily="$body"
+                  fontSize={11}
+                  color="$colorMuted"
+                  marginTop="$1"
+                >
+                  {round.totalEntries} {formatUIText("entries")} ·{" "}
+                  {round.matchesCompleted ?? 0}/{round.matchesTotal}{" "}
+                  {formatUIText("matches done")}
+                </Text>
+                {isSettled && (
+                  <Text
+                    fontFamily="$body"
+                    fontSize={10}
+                    color="$colorMuted"
+                    marginTop="$2"
+                  >
+                    {formatUIText("tap any entry to reveal their strategy")}
+                  </Text>
+                )}
+              </Card>
+            )}
+          </>
+        }
+        renderItem={({ item, index }: { item: any; index: number }) => {
+          const isMe = item.userId === user?.id;
+          const label = item.email ? item.email.split("@")[0] : "player";
+          const delta = rankDeltas.get(item.userId) ?? 0;
+          const rank = item.rank ?? index + 1;
+          const canReveal = isSettled;
+
+          const content = (
+            <Card
+              marginBottom="$2"
+              padding="$3"
+              borderWidth={isMe ? 2 : 1}
+              borderColor={isMe ? "$accentBackground" : "$borderColor"}
+            >
+              <XStack alignItems="center">
+                <YStack width={36} alignItems="center">
+                  <Text
+                    fontFamily="$mono"
+                    fontWeight="800"
+                    fontSize={14}
+                    color={
+                      index === 0
+                        ? "$colorCricket"
+                        : index === 1
+                          ? "$colorSecondary"
+                          : "$color"
+                    }
+                  >
+                    #{rank}
+                  </Text>
+                  {/* Rank movement arrow */}
+                  {delta !== 0 && !isSettled && (
+                    <Text
+                      fontFamily="$mono"
+                      fontSize={9}
+                      fontWeight="800"
+                      color={delta > 0 ? "$accentBackground" : "$colorHatch"}
+                    >
+                      {delta > 0 ? "▲" : "▼"}
+                      {Math.abs(delta)}
+                    </Text>
+                  )}
+                </YStack>
+                <XStack
+                  alignItems="center"
+                  gap="$2"
+                  flex={1}
+                  marginLeft="$2"
+                >
+                  <InitialsAvatar
+                    name={label}
+                    playerRole="BAT"
+                    ovr={0}
+                    size={32}
+                    hideBadge
+                  />
+                  <YStack flex={1}>
+                    <Text {...textStyles.playerName}>{label}</Text>
+                    {isMe && (
+                      <Badge
+                        variant="live"
+                        size="sm"
+                        alignSelf="flex-start"
+                      >
+                        {formatUIText("you")}
+                      </Badge>
+                    )}
+                  </YStack>
+                </XStack>
+                <YStack alignItems="flex-end" gap={2}>
+                  <Text
+                    fontFamily="$mono"
+                    fontWeight="700"
+                    fontSize={15}
+                    color="$accentBackground"
+                  >
+                    NRR {Number(item.nrr).toFixed(2)}
+                  </Text>
+                  <XStack gap="$2">
+                    <Text
+                      fontFamily="$mono"
+                      fontSize={10}
+                      color="$colorMuted"
+                    >
+                      B {item.battingTotal}
+                    </Text>
+                    <Text
+                      fontFamily="$mono"
+                      fontSize={10}
+                      color="$colorMuted"
+                    >
+                      W {item.bowlingTotal}
+                    </Text>
+                  </XStack>
+                  {item.prizeWon > 0 && (
+                    <Text
+                      fontFamily="$mono"
+                      fontSize={10}
+                      color="$colorCricket"
+                    >
+                      +{item.prizeWon} PC
+                    </Text>
+                  )}
+                </YStack>
+              </XStack>
+            </Card>
+          );
+
+          return (
+            <Animated.View
+              entering={FadeInDown.delay(Math.min(index * 25, 400)).springify()}
+            >
+              {canReveal ? (
+                <Pressable
+                  onPress={() =>
+                    router.push(
+                      `/league/${leagueId}/round/${roundId}/reveal/${item.userId}` as never
+                    )
+                  }
+                >
+                  {content}
+                </Pressable>
+              ) : (
+                content
+              )}
+            </Animated.View>
+          );
+        }}
+        ListEmptyComponent={
+          <Card padding="$5" alignItems="center">
+            <Text {...textStyles.hint}>
+              {formatUIText("no entries yet — be the first to play this round")}
+            </Text>
+          </Card>
+        }
+      />
+    </YStack>
+  );
+}

--- a/apps/mobile/app/league/[id]/round/[roundId]/reveal/[userId].tsx
+++ b/apps/mobile/app/league/[id]/round/[roundId]/reveal/[userId].tsx
@@ -1,0 +1,438 @@
+import { SafeBackButton } from "../../../../../../components/SafeBackButton";
+import { ScrollView } from "react-native";
+import { useLocalSearchParams } from "expo-router";
+import { useMemo } from "react";
+import Animated, { FadeInDown } from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { YStack, XStack } from "tamagui";
+import { Text } from "../../../../../../components/SportText";
+import {
+  Card,
+  Badge,
+  InitialsAvatar,
+  EggLoadingSpinner,
+  textStyles,
+  formatUIText,
+} from "@draftplay/ui";
+import { trpc } from "../../../../../../lib/trpc";
+import { HeaderControls } from "../../../../../../components/HeaderControls";
+
+type RoleKey = "BAT" | "BOWL" | "AR" | "WK";
+
+function roleToBadge(role: string): RoleKey {
+  if (role === "bowler") return "BOWL";
+  if (role === "all_rounder") return "AR";
+  if (role === "wicket_keeper") return "WK";
+  return "BAT";
+}
+
+export default function RevealScreen() {
+  const { roundId, userId } = useLocalSearchParams<{
+    id: string;
+    roundId: string;
+    userId: string;
+  }>();
+  const insets = useSafeAreaInsets();
+
+  const roundQuery = trpc.cricketManager.getRound.useQuery(
+    { roundId: roundId! },
+    { enabled: !!roundId }
+  );
+  const entryQuery = trpc.cricketManager.getEntryDetail.useQuery(
+    { roundId: roundId!, userId: userId! },
+    { enabled: !!roundId && !!userId }
+  );
+
+  const eligibleById = useMemo(() => {
+    const pool = (roundQuery.data?.eligiblePlayers ?? []) as Array<{
+      playerId: string;
+      name: string;
+      team: string;
+      role: string;
+      photoUrl?: string | null;
+    }>;
+    return new Map(pool.map((p) => [p.playerId, p]));
+  }, [roundQuery.data?.eligiblePlayers]);
+
+  if (roundQuery.isLoading || entryQuery.isLoading) {
+    return (
+      <YStack
+        flex={1}
+        backgroundColor="$background"
+        justifyContent="center"
+        alignItems="center"
+      >
+        <EggLoadingSpinner size={48} message="loading reveal" />
+      </YStack>
+    );
+  }
+
+  if (entryQuery.error) {
+    return (
+      <YStack
+        flex={1}
+        backgroundColor="$background"
+        justifyContent="center"
+        alignItems="center"
+        padding="$6"
+      >
+        <Text {...textStyles.hint} textAlign="center">
+          {entryQuery.error.message ?? "entry unavailable"}
+        </Text>
+      </YStack>
+    );
+  }
+
+  const entry = entryQuery.data;
+  const round = roundQuery.data;
+  if (!entry || !round) {
+    return (
+      <YStack
+        flex={1}
+        backgroundColor="$background"
+        justifyContent="center"
+        alignItems="center"
+      >
+        <Text {...textStyles.hint}>{formatUIText("entry not found")}</Text>
+      </YStack>
+    );
+  }
+
+  const battingOrder = (
+    (entry.battingOrder ?? []) as Array<{
+      position: number;
+      playerId: string;
+    }>
+  )
+    .slice()
+    .sort((a, b) => a.position - b.position);
+  const bowlingPriority = (
+    (entry.bowlingPriority ?? []) as Array<{
+      priority: number;
+      playerId: string;
+    }>
+  )
+    .slice()
+    .sort((a, b) => a.priority - b.priority);
+
+  const battingDetails = new Map<
+    string,
+    {
+      runs: number;
+      ballsFaced: number;
+      dismissed: boolean;
+      status: "full" | "partial" | "didnt_bat";
+    }
+  >();
+  for (const d of (entry.battingDetails ?? []) as Array<{
+    playerId: string;
+    runs: number;
+    ballsFaced: number;
+    dismissed: boolean;
+    status: "full" | "partial" | "didnt_bat";
+  }>) {
+    battingDetails.set(d.playerId, d);
+  }
+
+  const bowlingDetails = new Map<
+    string,
+    { cappedOvers: number; runsConceded: number; wickets: number }
+  >();
+  for (const d of (entry.bowlingDetails ?? []) as Array<{
+    playerId: string;
+    cappedOvers: number;
+    runsConceded: number;
+    wickets: number;
+  }>) {
+    bowlingDetails.set(d.playerId, d);
+  }
+
+  const toss = (entry as { toss?: string }).toss ?? "bat_first";
+
+  return (
+    <YStack flex={1} backgroundColor="$background">
+      <ScrollView
+        contentContainerStyle={{
+          padding: 16,
+          paddingTop: insets.top + 16,
+          paddingBottom: insets.bottom + 24,
+        }}
+      >
+        <XStack
+          justifyContent="space-between"
+          alignItems="center"
+          marginBottom="$4"
+        >
+          <XStack alignItems="center" gap="$3">
+            <SafeBackButton />
+            <Text
+              fontFamily="$mono"
+              fontWeight="500"
+              fontSize={17}
+              color="$color"
+              letterSpacing={-0.5}
+            >
+              {formatUIText("strategy reveal")}
+            </Text>
+          </XStack>
+          <HeaderControls />
+        </XStack>
+
+        {/* Summary header */}
+        <Animated.View entering={FadeInDown.delay(40).springify()}>
+          <Card
+            padding="$5"
+            marginBottom="$4"
+            borderWidth={1}
+            borderColor="$accentBackground"
+          >
+            <Text
+              fontFamily="$mono"
+              fontSize={10}
+              color="$colorMuted"
+              textTransform="uppercase"
+              letterSpacing={1}
+            >
+              {round.name}
+            </Text>
+            <XStack gap="$4" marginTop="$2" flexWrap="wrap">
+              <YStack>
+                <Text
+                  fontFamily="$body"
+                  fontSize={10}
+                  color="$colorMuted"
+                >
+                  BAT
+                </Text>
+                <Text
+                  fontFamily="$mono"
+                  fontWeight="800"
+                  fontSize={20}
+                  color="$accentBackground"
+                >
+                  {entry.battingTotal}
+                </Text>
+              </YStack>
+              <YStack>
+                <Text
+                  fontFamily="$body"
+                  fontSize={10}
+                  color="$colorMuted"
+                >
+                  BOWL
+                </Text>
+                <Text
+                  fontFamily="$mono"
+                  fontWeight="800"
+                  fontSize={20}
+                  color="$colorCricket"
+                >
+                  {entry.bowlingTotal}
+                </Text>
+              </YStack>
+              <YStack>
+                <Text
+                  fontFamily="$body"
+                  fontSize={10}
+                  color="$colorMuted"
+                >
+                  NRR
+                </Text>
+                <Text
+                  fontFamily="$mono"
+                  fontWeight="800"
+                  fontSize={20}
+                  color="$color"
+                >
+                  {Number(entry.nrr).toFixed(2)}
+                </Text>
+              </YStack>
+            </XStack>
+            <XStack gap="$2" marginTop="$3" flexWrap="wrap">
+              <Badge variant="role" size="sm">
+                {toss === "bowl_first" ? "🎯 bowl first" : "🏏 bat first"}
+              </Badge>
+              <Badge variant="role" size="sm">
+                {entry.battingWickets} wkts lost
+              </Badge>
+              <Badge variant="role" size="sm">
+                {entry.bowlingWickets} wkts taken
+              </Badge>
+            </XStack>
+          </Card>
+        </Animated.View>
+
+        {/* Batting order reveal */}
+        <Text
+          fontFamily="$mono"
+          fontSize={11}
+          color="$colorMuted"
+          textTransform="uppercase"
+          letterSpacing={1}
+          marginBottom="$2"
+        >
+          {formatUIText("batting order")}
+        </Text>
+        {battingOrder.map((slot, i) => {
+          const p = eligibleById.get(slot.playerId);
+          if (!p) return null;
+          const d = battingDetails.get(slot.playerId);
+          return (
+            <Animated.View
+              key={`bat-${slot.playerId}`}
+              entering={FadeInDown.delay(80 + i * 30).springify()}
+            >
+              <Card padding="$3" marginBottom="$2">
+                <XStack alignItems="center" gap="$2">
+                  <YStack width={24} alignItems="center">
+                    <Text
+                      fontFamily="$mono"
+                      fontWeight="800"
+                      fontSize={13}
+                      color="$accentBackground"
+                    >
+                      {slot.position}
+                    </Text>
+                  </YStack>
+                  <InitialsAvatar
+                    name={p.name}
+                    playerRole={roleToBadge(p.role)}
+                    ovr={0}
+                    size={32}
+                    hideBadge
+                    imageUrl={p.photoUrl ?? undefined}
+                  />
+                  <YStack flex={1} marginLeft="$1">
+                    <Text
+                      fontFamily="$body"
+                      fontWeight="700"
+                      fontSize={13}
+                      color="$color"
+                      numberOfLines={1}
+                    >
+                      {p.name}
+                    </Text>
+                    <Text fontFamily="$mono" fontSize={10} color="$colorMuted">
+                      {p.team} · {roleToBadge(p.role)}
+                    </Text>
+                  </YStack>
+                  <YStack alignItems="flex-end">
+                    {d && d.status !== "didnt_bat" ? (
+                      <>
+                        <Text
+                          fontFamily="$mono"
+                          fontWeight="700"
+                          fontSize={13}
+                          color="$accentBackground"
+                        >
+                          {d.runs}
+                          {!d.dismissed ? "*" : ""} ({d.ballsFaced})
+                        </Text>
+                        <Text
+                          fontFamily="$mono"
+                          fontSize={9}
+                          color="$colorMuted"
+                        >
+                          {d.status === "partial" ? "partial" : d.dismissed ? "out" : "not out"}
+                        </Text>
+                      </>
+                    ) : (
+                      <Text
+                        fontFamily="$mono"
+                        fontSize={10}
+                        color="$colorMuted"
+                      >
+                        {formatUIText("dnb")}
+                      </Text>
+                    )}
+                  </YStack>
+                </XStack>
+              </Card>
+            </Animated.View>
+          );
+        })}
+
+        {/* Bowling order reveal */}
+        <Text
+          fontFamily="$mono"
+          fontSize={11}
+          color="$colorMuted"
+          textTransform="uppercase"
+          letterSpacing={1}
+          marginBottom="$2"
+          marginTop="$4"
+        >
+          {formatUIText("bowling order")}
+        </Text>
+        {bowlingPriority.map((slot, i) => {
+          const p = eligibleById.get(slot.playerId);
+          if (!p) return null;
+          const d = bowlingDetails.get(slot.playerId);
+          return (
+            <Animated.View
+              key={`bowl-${slot.playerId}`}
+              entering={FadeInDown.delay(80 + i * 30).springify()}
+            >
+              <Card padding="$3" marginBottom="$2">
+                <XStack alignItems="center" gap="$2">
+                  <YStack width={24} alignItems="center">
+                    <Text
+                      fontFamily="$mono"
+                      fontWeight="800"
+                      fontSize={13}
+                      color="$colorCricket"
+                    >
+                      {slot.priority}
+                    </Text>
+                  </YStack>
+                  <InitialsAvatar
+                    name={p.name}
+                    playerRole={roleToBadge(p.role)}
+                    ovr={0}
+                    size={32}
+                    hideBadge
+                    imageUrl={p.photoUrl ?? undefined}
+                  />
+                  <YStack flex={1} marginLeft="$1">
+                    <Text
+                      fontFamily="$body"
+                      fontWeight="700"
+                      fontSize={13}
+                      color="$color"
+                      numberOfLines={1}
+                    >
+                      {p.name}
+                    </Text>
+                    <Text fontFamily="$mono" fontSize={10} color="$colorMuted">
+                      {p.team} · {roleToBadge(p.role)}
+                    </Text>
+                  </YStack>
+                  <YStack alignItems="flex-end">
+                    {d && d.runsConceded > 0 ? (
+                      <Text
+                        fontFamily="$mono"
+                        fontWeight="700"
+                        fontSize={13}
+                        color="$colorCricket"
+                      >
+                        {d.cappedOvers.toFixed(1)}-{d.runsConceded}-{d.wickets}
+                      </Text>
+                    ) : (
+                      <Text
+                        fontFamily="$mono"
+                        fontSize={10}
+                        color="$colorMuted"
+                      >
+                        —
+                      </Text>
+                    )}
+                  </YStack>
+                </XStack>
+              </Card>
+            </Animated.View>
+          );
+        })}
+      </ScrollView>
+    </YStack>
+  );
+}

--- a/apps/mobile/app/league/create.tsx
+++ b/apps/mobile/app/league/create.tsx
@@ -24,6 +24,7 @@ import { HeaderControls } from "../../components/HeaderControls";
 import { usePaywall } from "../../hooks/usePaywall";
 import { useSubscription } from "../../hooks/useSubscription";
 
+// cricket_manager is admin-only — players browse/join those via "Public Leagues"
 type LeagueFormat = "salary_cap" | "draft" | "auction" | "prediction";
 
 const FORMATS: { value: LeagueFormat; label: string; desc: string; comingSoon?: boolean }[] = [

--- a/apps/mobile/app/league/index.tsx
+++ b/apps/mobile/app/league/index.tsx
@@ -1,5 +1,5 @@
 import { SafeBackButton } from "../../components/SafeBackButton";
-import { FlatList, RefreshControl } from "react-native";
+import { FlatList, RefreshControl, ScrollView, Dimensions } from "react-native";
 import { useRouter } from "expo-router";
 import { useState } from "react";
 import Animated, { FadeInDown } from "react-native-reanimated";
@@ -28,11 +28,35 @@ export default function LeaguesListScreen() {
   const insets = useSafeAreaInsets();
   const theme = useTamaguiTheme();
   const { data: memberships, isLoading, refetch } = trpc.league.myLeagues.useQuery();
+  const publicLeagues = trpc.league.browsePublic.useQuery();
+  const joinPublic = trpc.league.joinPublic.useMutation({
+    onSuccess: (league: { id: string } | undefined) => {
+      publicLeagues.refetch();
+      refetch();
+      if (league) router.push(`/league/${league.id}` as any);
+    },
+  });
+  // CM leagues go through joinCmLeague which charges the entry fee
+  const joinCmLeagueMut = trpc.cricketManager.joinLeague.useMutation({
+    onSuccess: (league: { id: string } | undefined) => {
+      publicLeagues.refetch();
+      refetch();
+      if (league) router.push(`/league/${league.id}` as any);
+    },
+  });
+
+  function joinPublicLeague(leagueId: string, format: string) {
+    if (format === "cricket_manager") {
+      joinCmLeagueMut.mutate({ leagueId });
+    } else {
+      joinPublic.mutate({ leagueId });
+    }
+  }
   const [refreshing, setRefreshing] = useState(false);
 
   const onRefresh = async () => {
     setRefreshing(true);
-    await refetch();
+    await Promise.all([refetch(), publicLeagues.refetch()]);
     setRefreshing(false);
   };
 
@@ -104,16 +128,287 @@ export default function LeaguesListScreen() {
             <YStack alignItems="center" marginTop="$8">
               <EggLoadingSpinner size={48} message={formatUIText("loading leagues")} />
             </YStack>
-          ) : (
-            <YStack alignItems="center" marginTop="$8">
-              <DraftPlayLogo size={DesignSystem.emptyState.iconSize} />
-              <Text {...textStyles.hint} textAlign="center" lineHeight={20}>
-                {formatUIText("no leagues yet\ncreate or join a league to get started")}
-              </Text>
-            </YStack>
-          )
+          ) : null
+        }
+        ListFooterComponent={
+          <PublicLeaguesSection
+            leagues={publicLeagues.data ?? []}
+            onJoin={joinPublicLeague}
+            joining={joinPublic.isPending || joinCmLeagueMut.isPending}
+          />
         }
       />
     </YStack>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public leagues — creative discovery: hero carousel + list
+// ─────────────────────────────────────────────────────────────────────────────
+
+const SCREEN_WIDTH = Dimensions.get("window").width;
+const HERO_CARD_WIDTH = Math.min(300, SCREEN_WIDTH - 64);
+
+const FORMAT_META: Record<
+  string,
+  { label: string; emoji: string; accent: "accent" | "cricket" | "hatch" }
+> = {
+  cricket_manager: { label: "cricket manager", emoji: "🏆", accent: "cricket" },
+  salary_cap: { label: "salary cap", emoji: "💰", accent: "accent" },
+  draft: { label: "snake draft", emoji: "🐍", accent: "accent" },
+  auction: { label: "auction", emoji: "🔨", accent: "hatch" },
+  prediction: { label: "prediction", emoji: "🔮", accent: "accent" },
+};
+
+function PublicLeaguesSection({
+  leagues,
+  onJoin,
+  joining,
+}: {
+  leagues: any[];
+  onJoin: (leagueId: string, format: string) => void;
+  joining: boolean;
+}) {
+  if (leagues.length === 0) {
+    return (
+      <YStack marginTop="$6">
+        <SectionLabel>open leagues to join</SectionLabel>
+        <Card padding="$5" alignItems="center">
+          <Text {...textStyles.hint} textAlign="center">
+            {formatUIText(
+              "no open leagues right now\ncheck back soon — new mega leagues drop every week"
+            )}
+          </Text>
+        </Card>
+      </YStack>
+    );
+  }
+
+  // Featured = top 3 by prize pool (or first 3 if no pools)
+  const featured = [...leagues]
+    .sort(
+      (a, b) =>
+        (b.rules?.cricketManager?.prizePool ?? 0) -
+        (a.rules?.cricketManager?.prizePool ?? 0)
+    )
+    .slice(0, 3);
+
+  const rest = leagues.filter((l) => !featured.includes(l));
+
+  return (
+    <YStack marginTop="$6">
+      <SectionLabel>🌟 featured leagues</SectionLabel>
+
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={{ paddingRight: 16, paddingBottom: 8 }}
+        style={{ marginHorizontal: -16, paddingHorizontal: 16 }}
+      >
+        {featured.map((league, i) => (
+          <Animated.View
+            key={league.id}
+            entering={FadeInDown.delay(i * 60).springify()}
+            style={{ marginRight: 12 }}
+          >
+            <HeroLeagueCard
+              league={league}
+              onJoin={() => onJoin(league.id, league.format)}
+              joining={joining}
+            />
+          </Animated.View>
+        ))}
+      </ScrollView>
+
+      {rest.length > 0 && (
+        <>
+          <YStack marginTop="$5">
+            <SectionLabel>all public leagues</SectionLabel>
+          </YStack>
+          {rest.map((league, i) => (
+            <Animated.View
+              key={league.id}
+              entering={FadeInDown.delay(i * 40).springify()}
+            >
+              <CompactLeagueRow
+                league={league}
+                onJoin={() => onJoin(league.id, league.format)}
+                joining={joining}
+              />
+            </Animated.View>
+          ))}
+        </>
+      )}
+    </YStack>
+  );
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <Text
+      fontFamily="$mono"
+      fontSize={12}
+      color="$colorMuted"
+      textTransform="uppercase"
+      letterSpacing={1}
+      marginBottom="$3"
+    >
+      {children}
+    </Text>
+  );
+}
+
+function HeroLeagueCard({
+  league,
+  onJoin,
+  joining,
+}: {
+  league: any;
+  onJoin: () => void;
+  joining: boolean;
+}) {
+  const meta = FORMAT_META[league.format] ?? FORMAT_META.salary_cap!;
+  const cmCfg = league.rules?.cricketManager;
+  const prizePool: number = cmCfg?.prizePool ?? 0;
+  const entryFee: number = cmCfg?.entryFee ?? 0;
+  const accentColor =
+    meta.accent === "cricket"
+      ? "$colorCricket"
+      : meta.accent === "hatch"
+      ? "$colorHatch"
+      : "$accentBackground";
+
+  return (
+    <Card
+      width={HERO_CARD_WIDTH}
+      padding="$5"
+      borderWidth={2}
+      borderColor={accentColor}
+      pressable
+      onPress={onJoin}
+    >
+      <XStack alignItems="center" gap="$2" marginBottom="$3">
+        <Text fontSize={24}>{meta.emoji}</Text>
+        <Badge variant="role" size="sm">
+          {meta.label}
+        </Badge>
+      </XStack>
+
+      <Text
+        fontFamily="$mono"
+        fontWeight="700"
+        fontSize={20}
+        color="$color"
+        letterSpacing={-0.5}
+        numberOfLines={2}
+      >
+        {league.name}
+      </Text>
+      <Text
+        fontFamily="$body"
+        fontSize={12}
+        color="$colorMuted"
+        marginTop={2}
+        numberOfLines={1}
+      >
+        {league.tournament}
+      </Text>
+
+      {prizePool > 0 && (
+        <YStack marginTop="$4">
+          <Text fontFamily="$body" fontSize={11} color="$colorMuted">
+            {formatUIText("prize pool")}
+          </Text>
+          <Text
+            fontFamily="$mono"
+            fontWeight="800"
+            fontSize={28}
+            color={accentColor}
+            letterSpacing={-1}
+          >
+            {prizePool.toLocaleString()} PC
+          </Text>
+        </YStack>
+      )}
+
+      <XStack marginTop="$3" gap="$3" flexWrap="wrap">
+        <Badge variant="role" size="sm">
+          max {league.maxMembers}
+        </Badge>
+        <Badge variant="role" size="sm">
+          {entryFee > 0 ? `${entryFee} PC entry` : "free entry"}
+        </Badge>
+      </XStack>
+
+      <Button
+        variant="primary"
+        size="md"
+        marginTop="$4"
+        disabled={joining}
+        onPress={onJoin}
+      >
+        {joining ? formatUIText("joining...") : formatUIText("join league")}
+      </Button>
+    </Card>
+  );
+}
+
+function CompactLeagueRow({
+  league,
+  onJoin,
+  joining,
+}: {
+  league: any;
+  onJoin: () => void;
+  joining: boolean;
+}) {
+  const meta = FORMAT_META[league.format] ?? FORMAT_META.salary_cap!;
+  const cmCfg = league.rules?.cricketManager;
+  const prizePool: number = cmCfg?.prizePool ?? 0;
+
+  return (
+    <Card marginBottom="$3" padding="$4" pressable onPress={onJoin}>
+      <XStack alignItems="center" gap="$3">
+        <Text fontSize={22}>{meta.emoji}</Text>
+        <YStack flex={1}>
+          <Text {...textStyles.playerName} fontSize={15} numberOfLines={1}>
+            {league.name}
+          </Text>
+          <XStack gap="$2" marginTop={2} alignItems="center">
+            <Text
+              fontFamily="$body"
+              fontSize={11}
+              color="$colorMuted"
+              numberOfLines={1}
+            >
+              {league.tournament}
+            </Text>
+            {prizePool > 0 && (
+              <>
+                <Text fontFamily="$mono" fontSize={11} color="$colorMuted">
+                  ·
+                </Text>
+                <Text
+                  fontFamily="$mono"
+                  fontSize={11}
+                  color="$colorCricket"
+                  fontWeight="700"
+                >
+                  {prizePool.toLocaleString()} PC
+                </Text>
+              </>
+            )}
+          </XStack>
+        </YStack>
+        <Button
+          variant="primary"
+          size="sm"
+          disabled={joining}
+          onPress={onJoin}
+        >
+          {formatUIText("join")}
+        </Button>
+      </XStack>
+    </Card>
   );
 }

--- a/apps/mobile/app/wallet/index.tsx
+++ b/apps/mobile/app/wallet/index.tsx
@@ -31,7 +31,25 @@ const TXN_LABELS: Record<string, string> = {
   pack_purchase: "coin pack",
   streak_bonus: "streak bonus",
   achievement: "achievement",
+  cm_contest_entry: "cricket manager entry",
+  cm_contest_win: "cricket manager win",
+  cm_league_entry: "cricket manager league entry",
 };
+
+// The signup bonus is logged with type=achievement + metadata.reason=signup_bonus.
+// Detect it and override the label so it reads as "sign on bonus" instead of
+// the generic "achievement".
+function txnLabel(type: string, metadata: unknown): string {
+  if (
+    type === "achievement" &&
+    metadata &&
+    typeof metadata === "object" &&
+    (metadata as { reason?: unknown }).reason === "signup_bonus"
+  ) {
+    return "sign on bonus";
+  }
+  return TXN_LABELS[type] ?? type;
+}
 
 const CREDIT_TYPES = new Set([
   "daily_claim",
@@ -40,6 +58,7 @@ const CREDIT_TYPES = new Set([
   "referral_bonus",
   "streak_bonus",
   "achievement",
+  "cm_contest_win",
 ]);
 
 function StreakPulseDot({ day, isMilestone }: { day: number; isMilestone: boolean }) {
@@ -318,7 +337,7 @@ export default function WalletScreen() {
                   <XStack justifyContent="space-between" alignItems="center">
                     <YStack flex={1}>
                       <Text fontFamily="$mono" fontWeight="600" fontSize={13} color="$color">
-                        {formatBadgeText(TXN_LABELS[txn.type] ?? txn.type)}
+                        {formatBadgeText(txnLabel(txn.type, txn.metadata))}
                       </Text>
                       <Text fontFamily="$mono" fontSize={11} color="$colorMuted" marginTop={2}>
                         {new Date(txn.createdAt).toLocaleDateString("en-US", { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" })}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": "expo-router/entry",
   "scripts": {
-    "dev": "expo start",
+    "dev": "expo start --clear",
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
@@ -48,6 +48,7 @@
     "react-dom": "19.1.0",
     "react-hook-form": "^7.54.0",
     "react-native": "0.81.5",
+    "react-native-draggable-flatlist": "^4.0.3",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-qrcode-svg": "^6.3.21",
     "react-native-reanimated": "~4.1.1",

--- a/apps/web/src/app/admin/_components/AdminSidebar.tsx
+++ b/apps/web/src/app/admin/_components/AdminSidebar.tsx
@@ -12,6 +12,7 @@ const NAV_ITEMS: { href: string; label: string; icon: string; adminOnly?: boolea
   { href: "/admin/matches", label: "Matches", icon: "M", adminOnly: true },
   { href: "/admin/players", label: "Players", icon: "P", adminOnly: true },
   { href: "/admin/contests", label: "Contests", icon: "C", adminOnly: true },
+  { href: "/admin/leagues", label: "Admin Leagues", icon: "G", adminOnly: true },
   { href: "/admin/subscriptions", label: "Subscriptions", icon: "★", adminOnly: true },
   { href: "/admin/config", label: "Config", icon: "#", adminOnly: true },
   { href: "/admin/league-config", label: "League Config", icon: "L", adminOnly: true },

--- a/apps/web/src/app/admin/leagues/[id]/page.tsx
+++ b/apps/web/src/app/admin/leagues/[id]/page.tsx
@@ -1,0 +1,485 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import { trpc } from "@/lib/trpc";
+
+const FORMAT_LABELS: Record<string, string> = {
+  cricket_manager: "Cricket Manager",
+  salary_cap: "Salary Cap",
+  draft: "Draft",
+  auction: "Auction",
+  prediction: "Prediction",
+};
+
+export default function AdminLeagueDetailPage() {
+  const params = useParams();
+  const id = typeof params?.id === "string" ? params.id : Array.isArray(params?.id) ? params.id[0] : "";
+
+  const leagueQuery = trpc.admin.leagues.get.useQuery(
+    { leagueId: id },
+    { enabled: !!id }
+  );
+
+  if (!id) return <div>Missing league id</div>;
+  if (leagueQuery.isLoading) return <div>Loading…</div>;
+  if (!leagueQuery.data) return <div>League not found</div>;
+
+  const league = leagueQuery.data;
+
+  return (
+    <div style={{ maxWidth: 1100 }}>
+      <div style={{ marginBottom: 24 }}>
+        <Link
+          href="/admin/leagues"
+          style={{ fontSize: 13, color: "var(--text-secondary)", textDecoration: "none" }}
+        >
+          ← Admin Leagues
+        </Link>
+        <h1 style={{ fontSize: 26, fontWeight: 700, marginTop: 8 }}>{league.name}</h1>
+        <div style={{ display: "flex", gap: 12, marginTop: 8, fontSize: 13, color: "var(--text-secondary)", flexWrap: "wrap" }}>
+          <Tag>{FORMAT_LABELS[league.format] ?? league.format}</Tag>
+          <Tag>{league.tournament}</Tag>
+          <Tag>{league.isPrivate ? "Private" : "Public"}</Tag>
+          <Tag>max {league.maxMembers}</Tag>
+          <Tag>status: {league.status}</Tag>
+          <Tag>{league.members?.length ?? 0} member(s)</Tag>
+        </div>
+      </div>
+
+      {league.format === "cricket_manager" ? (
+        <CricketManagerSection leagueId={id} tournament={league.tournament} />
+      ) : (
+        <div
+          style={{
+            padding: 24,
+            backgroundColor: "var(--bg-surface)",
+            borderRadius: 8,
+            border: "1px solid var(--border)",
+            color: "var(--text-secondary)",
+            fontSize: 14,
+          }}
+        >
+          This league format uses the standard contest flow. Contests are auto-created from the
+          league's tournament schedule. Manage them via the Contests page.
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Cricket Manager section (rounds + composer) ───────────────────────────
+
+function CricketManagerSection({
+  leagueId,
+  tournament,
+}: {
+  leagueId: string;
+  tournament: string;
+}) {
+  const roundsQuery = trpc.cricketManager.getLeagueRounds.useQuery({ leagueId });
+  const [showComposer, setShowComposer] = useState(false);
+
+  return (
+    <div>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 16,
+        }}
+      >
+        <h2 style={{ fontSize: 18, fontWeight: 700 }}>Rounds</h2>
+        <button
+          onClick={() => setShowComposer((v) => !v)}
+          style={{
+            padding: "8px 16px",
+            backgroundColor: showComposer ? "var(--bg-surface)" : "var(--accent)",
+            color: showComposer ? "var(--text-primary)" : "white",
+            border: showComposer ? "1px solid var(--border)" : "none",
+            borderRadius: 6,
+            fontSize: 13,
+            fontWeight: 600,
+            cursor: "pointer",
+          }}
+        >
+          {showComposer ? "Cancel" : "+ Compose Round"}
+        </button>
+      </div>
+
+      {showComposer && (
+        <RoundComposer
+          leagueId={leagueId}
+          tournament={tournament}
+          nextRoundNumber={(roundsQuery.data?.length ?? 0) + 1}
+          onCreated={() => {
+            setShowComposer(false);
+            roundsQuery.refetch();
+          }}
+        />
+      )}
+
+      <div style={{ marginTop: 16 }}>
+        {roundsQuery.isLoading ? (
+          <div style={{ color: "var(--text-secondary)" }}>Loading rounds…</div>
+        ) : (roundsQuery.data ?? []).length === 0 ? (
+          <div
+            style={{
+              padding: 32,
+              textAlign: "center",
+              backgroundColor: "var(--bg-surface)",
+              border: "1px dashed var(--border)",
+              borderRadius: 8,
+              color: "var(--text-secondary)",
+              fontSize: 14,
+            }}
+          >
+            No rounds yet. Compose your first round above.
+          </div>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {(roundsQuery.data ?? []).map((r: any) => (
+              <RoundRow
+                key={r.id}
+                round={r}
+                onChanged={() => roundsQuery.refetch()}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function RoundRow({
+  round,
+  onChanged,
+}: {
+  round: any;
+  onChanged: () => void;
+}) {
+  const deleteRound = trpc.cricketManager.deleteRound.useMutation({ onSuccess: onChanged });
+
+  return (
+    <div
+      style={{
+        padding: 16,
+        backgroundColor: "var(--bg-surface)",
+        border: "1px solid var(--border)",
+        borderRadius: 8,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 12,
+      }}
+    >
+      <div>
+        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <span
+            style={{
+              fontFamily: "var(--font-data)",
+              fontSize: 12,
+              fontWeight: 700,
+              backgroundColor: "rgba(61,153,104,0.1)",
+              color: "var(--accent)",
+              padding: "2px 8px",
+              borderRadius: 4,
+            }}
+          >
+            R{round.roundNumber}
+          </span>
+          <div style={{ fontSize: 15, fontWeight: 600 }}>{round.name}</div>
+          <Tag>{round.status}</Tag>
+        </div>
+        <div style={{ marginTop: 6, fontSize: 12, color: "var(--text-secondary)" }}>
+          {round.matchesTotal} matches · window {formatDate(round.windowStart)} →{" "}
+          {formatDate(round.windowEnd)} · lock {formatDate(round.lockTime)}
+          {round.totalEntries > 0 && ` · ${round.totalEntries} entries`}
+        </div>
+      </div>
+
+      <div style={{ display: "flex", gap: 6 }}>
+        {round.status === "upcoming" && (
+          <button
+            onClick={() => {
+              if (confirm(`Delete round "${round.name}"?`))
+                deleteRound.mutate({ roundId: round.id });
+            }}
+            style={actionBtn("danger")}
+          >
+            Delete
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function RoundComposer({
+  leagueId,
+  tournament,
+  nextRoundNumber,
+  onCreated,
+}: {
+  leagueId: string;
+  tournament: string;
+  nextRoundNumber: number;
+  onCreated: () => void;
+}) {
+  const matchesQuery = trpc.admin.matches.list.useQuery({
+    tournament,
+    limit: 500,
+  });
+  const compose = trpc.cricketManager.composeRound.useMutation({
+    onSuccess: onCreated,
+  });
+
+  const [roundNumber, setRoundNumber] = useState(nextRoundNumber);
+  const [name, setName] = useState(`Round ${nextRoundNumber}`);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [error, setError] = useState<string | null>(null);
+
+  const sortedMatches = useMemo(() => {
+    return [...(matchesQuery.data ?? [])].sort(
+      (a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
+    );
+  }, [matchesQuery.data]);
+
+  function toggle(id: string) {
+    const next = new Set(selected);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    setSelected(next);
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (selected.size === 0) {
+      setError("Select at least one match");
+      return;
+    }
+    compose.mutate({
+      leagueId,
+      roundNumber,
+      name: name.trim() || `Round ${roundNumber}`,
+      matchIds: Array.from(selected),
+    });
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      style={{
+        padding: 16,
+        backgroundColor: "var(--bg-surface)",
+        border: "1px solid var(--border)",
+        borderRadius: 8,
+      }}
+    >
+      <div style={{ display: "flex", gap: 12, marginBottom: 12 }}>
+        <div style={{ width: 120 }}>
+          <label style={labelStyle}>Round #</label>
+          <input
+            type="number"
+            value={roundNumber}
+            onChange={(e) => setRoundNumber(Number(e.target.value))}
+            min={1}
+            style={inputStyle}
+          />
+        </div>
+        <div style={{ flex: 1 }}>
+          <label style={labelStyle}>Round name</label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            style={inputStyle}
+            placeholder="Round 1 — Opening Fixtures"
+          />
+        </div>
+      </div>
+
+      <label style={labelStyle}>
+        Matches ({selected.size} selected) — sorted by date
+      </label>
+      <div
+        style={{
+          maxHeight: 360,
+          overflow: "auto",
+          border: "1px solid var(--border)",
+          borderRadius: 6,
+          backgroundColor: "var(--bg)",
+        }}
+      >
+        {matchesQuery.isLoading ? (
+          <div style={{ padding: 12, color: "var(--text-secondary)", fontSize: 13 }}>
+            Loading matches…
+          </div>
+        ) : sortedMatches.length === 0 ? (
+          <div style={{ padding: 12, color: "var(--text-secondary)", fontSize: 13 }}>
+            No matches found for tournament "{tournament}".
+          </div>
+        ) : (
+          sortedMatches.map((m: any) => {
+            const isSelected = selected.has(m.id);
+            return (
+              <label
+                key={m.id}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 10,
+                  padding: "10px 12px",
+                  borderBottom: "1px solid var(--border)",
+                  cursor: "pointer",
+                  backgroundColor: isSelected
+                    ? "rgba(61,153,104,0.06)"
+                    : "transparent",
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={isSelected}
+                  onChange={() => toggle(m.id)}
+                />
+                <div style={{ flex: 1, display: "flex", gap: 10, alignItems: "center" }}>
+                  <span
+                    style={{
+                      fontFamily: "var(--font-data)",
+                      fontSize: 11,
+                      color: "var(--text-secondary)",
+                      minWidth: 130,
+                    }}
+                  >
+                    {formatDate(m.startTime)}
+                  </span>
+                  <span style={{ fontSize: 13, fontWeight: 500 }}>
+                    {m.teamHome} vs {m.teamAway}
+                  </span>
+                  <Tag>{m.status}</Tag>
+                </div>
+              </label>
+            );
+          })
+        )}
+      </div>
+
+      {error && (
+        <div
+          style={{
+            marginTop: 12,
+            padding: 10,
+            backgroundColor: "rgba(229,72,77,0.1)",
+            color: "var(--red)",
+            borderRadius: 6,
+            fontSize: 13,
+          }}
+        >
+          {error}
+        </div>
+      )}
+      {compose.error && (
+        <div
+          style={{
+            marginTop: 12,
+            padding: 10,
+            backgroundColor: "rgba(229,72,77,0.1)",
+            color: "var(--red)",
+            borderRadius: 6,
+            fontSize: 13,
+          }}
+        >
+          {compose.error.message}
+        </div>
+      )}
+
+      <div style={{ marginTop: 16 }}>
+        <button
+          type="submit"
+          disabled={compose.isPending}
+          style={{
+            padding: "8px 16px",
+            backgroundColor: "var(--accent)",
+            color: "white",
+            border: "none",
+            borderRadius: 6,
+            fontSize: 13,
+            fontWeight: 600,
+            cursor: compose.isPending ? "not-allowed" : "pointer",
+          }}
+        >
+          {compose.isPending ? "Composing…" : `Compose Round (${selected.size} matches)`}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function Tag({ children }: { children: React.ReactNode }) {
+  return (
+    <span
+      style={{
+        fontSize: 11,
+        padding: "2px 8px",
+        borderRadius: 4,
+        backgroundColor: "rgba(94,93,90,0.1)",
+        color: "var(--text-secondary)",
+        fontFamily: "var(--font-data)",
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function formatDate(d: string | Date): string {
+  const date = typeof d === "string" ? new Date(d) : d;
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "8px 10px",
+  border: "1px solid var(--border)",
+  borderRadius: 6,
+  backgroundColor: "var(--bg)",
+  color: "var(--text-primary)",
+  fontSize: 13,
+};
+
+const labelStyle: React.CSSProperties = {
+  display: "block",
+  fontSize: 12,
+  fontWeight: 600,
+  color: "var(--text-primary)",
+  marginBottom: 4,
+};
+
+function actionBtn(variant: "neutral" | "accent" | "danger"): React.CSSProperties {
+  const colors = {
+    neutral: { border: "var(--border)", color: "var(--text-primary)" },
+    accent: { border: "var(--accent)", color: "var(--accent)" },
+    danger: { border: "var(--red)", color: "var(--red)" },
+  }[variant];
+  return {
+    fontSize: 12,
+    padding: "6px 10px",
+    border: `1px solid ${colors.border}`,
+    borderRadius: 6,
+    backgroundColor: "transparent",
+    color: colors.color,
+    cursor: "pointer",
+    fontWeight: 500,
+  };
+}

--- a/apps/web/src/app/admin/leagues/new/page.tsx
+++ b/apps/web/src/app/admin/leagues/new/page.tsx
@@ -1,0 +1,373 @@
+"use client";
+
+import React, { useState, useMemo } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { trpc } from "@/lib/trpc";
+
+type Format =
+  | "cricket_manager"
+  | "salary_cap"
+  | "draft"
+  | "auction"
+  | "prediction";
+
+const FORMAT_OPTIONS: Array<{ value: Format; label: string; description: string }> = [
+  {
+    value: "cricket_manager",
+    label: "Cricket Manager",
+    description:
+      "Admin-curated rounds grouping matches. Members pick 11, set batting order + bowling priority, race NRR across rounds.",
+  },
+  {
+    value: "salary_cap",
+    label: "Salary Cap",
+    description: "Classic fantasy: pick players within a budget each match.",
+  },
+  {
+    value: "draft",
+    label: "Snake Draft",
+    description: "Members draft unique squads that score across matches.",
+  },
+  {
+    value: "auction",
+    label: "Auction",
+    description: "Members bid on players to build their squads.",
+  },
+  {
+    value: "prediction",
+    label: "Prediction",
+    description: "Predict match outcomes and events.",
+  },
+];
+
+export default function NewAdminLeaguePage() {
+  const router = useRouter();
+  const [format, setFormat] = useState<Format>("cricket_manager");
+  const [name, setName] = useState("");
+  const [tournament, setTournament] = useState<string>("");
+  const [maxMembers, setMaxMembers] = useState(100);
+  const [entryFee, setEntryFee] = useState(0);
+  const [prizePool, setPrizePool] = useState(0);
+  const [ballLimit, setBallLimit] = useState(120);
+  const [minBowlers, setMinBowlers] = useState(5);
+  const [maxOversPerBowler, setMaxOversPerBowler] = useState(4);
+  const [roundPct, setRoundPct] = useState(10);
+  const [finalPct, setFinalPct] = useState(50);
+  const [description, setDescription] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const tournaments = trpc.admin.tournaments.list.useQuery();
+  const tournamentOptions = useMemo(
+    () => (tournaments.data ?? []).map((t: { id: string; name: string }) => t),
+    [tournaments.data]
+  );
+
+  const create = trpc.admin.leagues.create.useMutation({
+    onSuccess: (league) => {
+      if (league) router.push(`/admin/leagues/${league.id}`);
+    },
+    onError: (err) => setError(err.message ?? "Failed to create league"),
+  });
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    if (!name.trim() || !tournament) {
+      setError("Name and tournament are required");
+      return;
+    }
+
+    const rules: Record<string, unknown> = {};
+    if (format === "cricket_manager") {
+      rules.cricketManager = {
+        ballLimit,
+        minBowlersInSquad: minBowlers,
+        maxOversPerBowler,
+        prizePool,
+        entryFee,
+        prizeDistribution: [
+          { rank: 1, percent: 50 },
+          { rank: 2, percent: 30 },
+          { rank: 3, percent: 20 },
+        ],
+        roundPrizeSplit: { perRoundPct: roundPct, finalPct },
+      };
+    }
+
+    create.mutate({
+      name: name.trim(),
+      format,
+      sport: "cricket",
+      tournament,
+      isPrivate: false,
+      maxMembers,
+      template: "custom",
+      rules,
+    });
+  }
+
+  return (
+    <div style={{ maxWidth: 720 }}>
+      <div style={{ marginBottom: 24 }}>
+        <Link
+          href="/admin/leagues"
+          style={{ fontSize: 13, color: "var(--text-secondary)", textDecoration: "none" }}
+        >
+          ← Admin Leagues
+        </Link>
+        <h1 style={{ fontSize: 24, fontWeight: 700, marginTop: 8 }}>New Admin League</h1>
+        <p style={{ fontSize: 13, color: "var(--text-secondary)", marginTop: 4 }}>
+          Leagues created here are public and owned by the platform. Behaviour is identical to
+          user-created leagues.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit}>
+        <Field label="Format">
+          <select
+            value={format}
+            onChange={(e) => setFormat(e.target.value as Format)}
+            style={inputStyle}
+          >
+            {FORMAT_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+          <p style={hintStyle}>
+            {FORMAT_OPTIONS.find((o) => o.value === format)?.description}
+          </p>
+        </Field>
+
+        <Field label="Name">
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="IPL 2026 Mega League"
+            style={inputStyle}
+            maxLength={100}
+          />
+        </Field>
+
+        <Field label="Description (optional)">
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={2}
+            style={{ ...inputStyle, resize: "vertical" }}
+          />
+        </Field>
+
+        <Field label="Tournament">
+          <select
+            value={tournament}
+            onChange={(e) => setTournament(e.target.value)}
+            style={inputStyle}
+          >
+            <option value="">Select tournament…</option>
+            {tournamentOptions.map((t: { id: string; name: string }) => (
+              <option key={t.id} value={t.name}>
+                {t.name}
+              </option>
+            ))}
+          </select>
+        </Field>
+
+        <Field label="Max Members">
+          <input
+            type="number"
+            value={maxMembers}
+            onChange={(e) => setMaxMembers(Number(e.target.value))}
+            min={2}
+            max={100000}
+            style={inputStyle}
+          />
+        </Field>
+
+        <Field label="Entry Fee (Pop Coins, one-time)">
+          <input
+            type="number"
+            value={entryFee}
+            onChange={(e) => setEntryFee(Number(e.target.value))}
+            min={0}
+            style={inputStyle}
+          />
+        </Field>
+
+        <Field label="Prize Pool (Pop Coins, guaranteed)">
+          <input
+            type="number"
+            value={prizePool}
+            onChange={(e) => setPrizePool(Number(e.target.value))}
+            min={0}
+            style={inputStyle}
+          />
+        </Field>
+
+        {format === "cricket_manager" && (
+          <>
+            <Divider label="Cricket Manager config" />
+
+            <Field label="Ball limit per innings">
+              <input
+                type="number"
+                value={ballLimit}
+                onChange={(e) => setBallLimit(Number(e.target.value))}
+                min={30}
+                max={300}
+                style={inputStyle}
+              />
+              <p style={hintStyle}>Default 120 (20 overs × 6 balls).</p>
+            </Field>
+
+            <Field label="Min bowlers in squad">
+              <input
+                type="number"
+                value={minBowlers}
+                onChange={(e) => setMinBowlers(Number(e.target.value))}
+                min={3}
+                max={7}
+                style={inputStyle}
+              />
+            </Field>
+
+            <Field label="Max overs per bowler">
+              <input
+                type="number"
+                value={maxOversPerBowler}
+                onChange={(e) => setMaxOversPerBowler(Number(e.target.value))}
+                min={1}
+                max={10}
+                style={inputStyle}
+              />
+            </Field>
+
+            <Field label="Prize split — per-round % of pool">
+              <input
+                type="number"
+                value={roundPct}
+                onChange={(e) => setRoundPct(Number(e.target.value))}
+                min={0}
+                max={100}
+                style={inputStyle}
+              />
+              <p style={hintStyle}>
+                % of total pool awarded at the end of each round. Rest is saved for final
+                standings.
+              </p>
+            </Field>
+
+            <Field label="Prize split — final % of pool">
+              <input
+                type="number"
+                value={finalPct}
+                onChange={(e) => setFinalPct(Number(e.target.value))}
+                min={0}
+                max={100}
+                style={inputStyle}
+              />
+            </Field>
+          </>
+        )}
+
+        {error && (
+          <div
+            style={{
+              padding: 12,
+              backgroundColor: "rgba(229,72,77,0.1)",
+              color: "var(--red)",
+              borderRadius: 6,
+              fontSize: 13,
+              marginBottom: 16,
+            }}
+          >
+            {error}
+          </div>
+        )}
+
+        <button
+          type="submit"
+          disabled={create.isPending}
+          style={{
+            padding: "10px 24px",
+            backgroundColor: "var(--accent)",
+            color: "white",
+            border: "none",
+            borderRadius: 6,
+            fontSize: 14,
+            fontWeight: 600,
+            cursor: create.isPending ? "not-allowed" : "pointer",
+            opacity: create.isPending ? 0.6 : 1,
+          }}
+        >
+          {create.isPending ? "Creating…" : "Create League"}
+        </button>
+      </form>
+    </div>
+  );
+}
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "8px 12px",
+  border: "1px solid var(--border)",
+  borderRadius: 6,
+  backgroundColor: "var(--bg-surface)",
+  color: "var(--text-primary)",
+  fontSize: 14,
+};
+
+const hintStyle: React.CSSProperties = {
+  fontSize: 12,
+  color: "var(--text-secondary)",
+  marginTop: 4,
+};
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div style={{ marginBottom: 16 }}>
+      <label
+        style={{
+          display: "block",
+          fontSize: 13,
+          fontWeight: 600,
+          color: "var(--text-primary)",
+          marginBottom: 6,
+        }}
+      >
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+function Divider({ label }: { label: string }) {
+  return (
+    <div
+      style={{
+        marginTop: 24,
+        marginBottom: 12,
+        paddingTop: 12,
+        borderTop: "1px solid var(--border)",
+        fontSize: 12,
+        fontWeight: 700,
+        color: "var(--text-secondary)",
+        textTransform: "uppercase",
+        letterSpacing: 0.8,
+      }}
+    >
+      {label}
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/leagues/page.tsx
+++ b/apps/web/src/app/admin/leagues/page.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import React, { useState } from "react";
+import Link from "next/link";
+import { trpc } from "@/lib/trpc";
+import { DataTable } from "../_components/DataTable";
+
+const PAGE_SIZE = 25;
+
+const FORMAT_LABELS: Record<string, string> = {
+  cricket_manager: "Cricket Manager",
+  salary_cap: "Salary Cap",
+  draft: "Draft",
+  auction: "Auction",
+  prediction: "Prediction",
+};
+
+export default function AdminLeaguesPage() {
+  const [page, setPage] = useState(0);
+  const [formatFilter, setFormatFilter] = useState<string>("");
+
+  const leaguesList = trpc.admin.leagues.list.useQuery({
+    format: (formatFilter || undefined) as
+      | "cricket_manager"
+      | "salary_cap"
+      | "draft"
+      | "auction"
+      | "prediction"
+      | undefined,
+    limit: PAGE_SIZE + 1,
+    offset: page * PAGE_SIZE,
+  });
+
+  const deleteLeague = trpc.admin.leagues.delete.useMutation({
+    onSuccess: () => leaguesList.refetch(),
+  });
+
+  const data = (leaguesList.data ?? []).slice(0, PAGE_SIZE);
+  const hasMore = (leaguesList.data ?? []).length > PAGE_SIZE;
+
+  return (
+    <div>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 24,
+        }}
+      >
+        <h1 style={{ fontSize: 24, fontWeight: 700 }}>Admin Leagues</h1>
+        <Link
+          href="/admin/leagues/new"
+          style={{
+            padding: "8px 16px",
+            backgroundColor: "var(--accent)",
+            color: "white",
+            borderRadius: 6,
+            fontSize: 14,
+            fontWeight: 600,
+            textDecoration: "none",
+          }}
+        >
+          + New League
+        </Link>
+      </div>
+
+      <div style={{ marginBottom: 16 }}>
+        <label style={{ fontSize: 13, color: "var(--text-secondary)", marginRight: 8 }}>
+          Format:
+        </label>
+        <select
+          value={formatFilter}
+          onChange={(e) => {
+            setFormatFilter(e.target.value);
+            setPage(0);
+          }}
+          style={{
+            padding: "6px 10px",
+            border: "1px solid var(--border)",
+            borderRadius: 6,
+            backgroundColor: "var(--bg-surface)",
+            color: "var(--text-primary)",
+            fontSize: 13,
+          }}
+        >
+          <option value="">All formats</option>
+          <option value="cricket_manager">Cricket Manager</option>
+          <option value="salary_cap">Salary Cap</option>
+          <option value="draft">Draft</option>
+          <option value="auction">Auction</option>
+          <option value="prediction">Prediction</option>
+        </select>
+      </div>
+
+      <DataTable
+        loading={leaguesList.isLoading}
+        data={data}
+        page={page}
+        onPageChange={setPage}
+        pageSize={PAGE_SIZE}
+        hasMore={hasMore}
+        columns={[
+          {
+            key: "name",
+            header: "Name",
+            render: (row) => (
+              <Link
+                href={`/admin/leagues/${row.id}`}
+                style={{ color: "var(--accent)", textDecoration: "none", fontWeight: 600 }}
+              >
+                {row.name}
+              </Link>
+            ),
+          },
+          {
+            key: "format",
+            header: "Format",
+            width: "160px",
+            render: (row) => (
+              <span
+                style={{
+                  padding: "2px 8px",
+                  borderRadius: 4,
+                  fontSize: 12,
+                  fontWeight: 600,
+                  backgroundColor: "rgba(61,153,104,0.1)",
+                  color: "var(--accent)",
+                  fontFamily: "var(--font-data)",
+                }}
+              >
+                {FORMAT_LABELS[row.format] ?? row.format}
+              </span>
+            ),
+          },
+          { key: "tournament", header: "Tournament" },
+          {
+            key: "visibility",
+            header: "Visibility",
+            width: "110px",
+            render: (row) => (row.isPrivate ? "Private" : "Public"),
+          },
+          {
+            key: "maxMembers",
+            header: "Members",
+            width: "90px",
+          },
+          {
+            key: "status",
+            header: "Status",
+            width: "100px",
+          },
+          {
+            key: "actions",
+            header: "",
+            width: "90px",
+            render: (row) => (
+              <button
+                onClick={() => {
+                  if (confirm(`Delete league "${row.name}"? This cannot be undone.`))
+                    deleteLeague.mutate({ leagueId: row.id });
+                }}
+                style={{
+                  fontSize: 12,
+                  padding: "4px 8px",
+                  border: "1px solid var(--red)",
+                  borderRadius: 6,
+                  backgroundColor: "transparent",
+                  color: "var(--red)",
+                  cursor: "pointer",
+                }}
+              >
+                Delete
+              </button>
+            ),
+          },
+        ]}
+      />
+    </div>
+  );
+}

--- a/docs/CRICKET_MANAGER_DRAFT.md
+++ b/docs/CRICKET_MANAGER_DRAFT.md
@@ -2,7 +2,7 @@
 
 > **Status:** Design Phase
 > **Working Title:** Cricket Manager
-> **Concept:** A no-budget, multi-member tactical contest. Members each pick 11 players from a multi-day match window, set their batting order and bowling priority, make a "Bat First / Bowl First" call, then watch a **live 120-ball internal match** unfold as real cricket happens. Each member's Batting Total races against their own Bowling Total — the resulting NRR is compared on a shared contest leaderboard. Highest NRR wins the prize pool.
+> **Concept:** A no-budget, multi-member tactical contest. Members each pick 11 players from a multi-day match window, set their batting order and bowling priority, then watch a **live 120-ball internal match** unfold as real cricket happens. Each member's Batting Total races against their own Bowling Total — the resulting NRR is compared on a shared contest leaderboard. Highest NRR wins the prize pool.
 
 ---
 
@@ -12,7 +12,7 @@
 2. [The 120-Ball Engine](#2-the-120-ball-engine)
 3. [Contest Structure (Multi-Member)](#3-contest-structure-multi-member)
 4. [Round Structure (Multi-Match Window)](#4-round-structure-multi-match-window)
-5. [The 4 Phases of a Round](#5-the-4-phases-of-a-round)
+5. [The 3 Phases of a Round](#5-the-3-phases-of-a-round)
 6. [Live Scoring & Progress](#6-live-scoring--progress)
 7. [Leaderboard & NRR](#7-leaderboard--nrr)
 8. [Data Requirements](#8-data-requirements)
@@ -66,7 +66,7 @@ LAYER 2 — THE CONTEST (all members)
        │
 2. MEMBERS JOIN              2-1000 members join, pay entry fee (Pop Coins)
        │
-3. EACH MEMBER BUILDS        Pick 11 → Set batting order → Set bowling priority → Toss call
+3. EACH MEMBER BUILDS        Pick 11 → Set batting order → Set bowling priority
    THEIR ENTRY               (independently, can't see others' picks)
        │
 4. ENTRIES LOCK              30 min before first match in the window
@@ -184,29 +184,17 @@ If the bowling order takes **10 wickets**, the Bowling Total **freezes at the mo
 - This rewards picking wicket-taking bowlers, not just economical ones
 - Creates a distinct strategy: "wicket-hunting" vs "run-suppressing"
 
-### 2.4 The Toss Bonus
-
-Before the round locks, each member makes a "Bat First" or "Bowl First" call:
-
-- **Bat First:** Final Batting Total = Raw Batting Total × 1.05 (+5%)
-- **Bowl First:** Final Bowling Total = Raw Bowling Total × 0.95 (-5%)
-
-Applied AFTER the 120-ball simulation, BEFORE NRR calculation.
-
-### 2.5 Victory Condition (Per Member)
+### 2.4 Victory Condition (Per Member)
 
 ```
-Adjusted Batting Total = battingTotal × (toss == 'bat_first' ? 1.05 : 1.0)
-Adjusted Bowling Total = bowlingTotal × (toss == 'bowl_first' ? 0.95 : 1.0)
-
-WIN:  Adjusted Batting Total > Adjusted Bowling Total
-LOSS: Adjusted Batting Total < Adjusted Bowling Total
-TIE:  Adjusted Batting Total == Adjusted Bowling Total
+WIN:  Batting Total > Bowling Total
+LOSS: Batting Total < Bowling Total
+TIE:  Batting Total == Bowling Total
 ```
 
 A "win" doesn't mean you win the contest — it means your batting beat your bowling. Your **NRR** determines where you rank among all members.
 
-### 2.6 All-Rounder Handling
+### 2.5 All-Rounder Handling
 
 A player who both bats and bowls contributes to **BOTH** sides of the simulation:
 
@@ -221,7 +209,7 @@ This is the core strategic tension. Example:
 
 The decision: is his batting value worth the bowling cost?
 
-### 2.7 Multi-Match Aggregation
+### 2.6 Multi-Match Aggregation
 
 Since a round spans multiple real matches, a player's stats are **summed across all matches** they play in the window:
 
@@ -250,17 +238,18 @@ If Bumrah plays twice in the window (MI vs CSK and MI vs DC) and bowls 4+4 = 8 o
 
 A CM contest is a **group of members** competing on the same round. Everyone picks from the same player pool, builds their entry independently, and is ranked by NRR on a shared leaderboard.
 
-Think of it like a golf tournament — everyone plays the same course (same player pool), but your score (NRR) depends entirely on your own strategy (squad, order, toss). There's no direct interaction between members during the game.
+Think of it like a golf tournament — everyone plays the same course (same player pool), but your score (NRR) depends entirely on your own strategy (squad, batting order, bowling priority). There's no direct interaction between members during the game.
 
 ### 3.2 Contest Types
 
 | Type | Members | Entry Fee | Prize Pool | Created By |
 |------|---------|-----------|------------|------------|
-| **Public** | Up to 100 | 10-100 PC | Entry fees pooled | System (auto per round) |
+| **Mega League** | Up to 10,000 | Set by admin | Guaranteed pool (set by admin) | **Admin** (one per tournament — the flagship public league) |
 | **Private** | 2-20 | Custom (or free) | Entry fees pooled | Any user (invite code) |
 | **H2H** | Exactly 2 | Matched stakes | Winner takes all | User-initiated |
-| **Mega** | Up to 1000 | 20 PC | Guaranteed pool | System (big match days) |
 | **Free** | Up to 50 | 0 PC | Small PC prizes | System (casual/onboarding) |
+
+The **Mega League** is the primary public contest: admin creates it, hand-composes rounds, defines prize pool, and users join it once to compete across the entire tournament. Private contests and H2H are user-initiated alternatives within the same round structure.
 
 ### 3.3 Prize Distribution
 
@@ -288,7 +277,7 @@ For larger contests (50+ members):
 |-------|---------------------|
 | **Building entries** | Nothing about other members' picks |
 | **Live phase** | Other members' NRR, batting total, bowling total — but NOT their squad, batting order, or bowling priority |
-| **After settlement** | Everything — full squad, batting order, bowling priority, toss call, per-player breakdown |
+| **After settlement** | Everything — full squad, batting order, bowling priority, per-player breakdown |
 
 This creates:
 - **During live:** Tension ("CricketGuru is ahead of me but I don't know why!")
@@ -300,47 +289,85 @@ A member can join **multiple contests** for the same round — but they submit t
 - Gaming by submitting different entries to hedge
 - Complexity of managing multiple squads
 
-One squad + one order + one toss = one entry. That entry competes in every contest you've joined for that round.
+One squad + one batting order + one bowling priority = one entry. That entry competes in every contest you've joined for that round.
 
 > **Design decision:** This is simpler and fairer. You commit to one strategy, and it's judged across all your contests. Same as most fantasy platforms.
 
 ---
 
-## 4. Round Structure (Multi-Match Window)
+## 4. Round Structure (Admin-Curated Match Groupings)
 
 ### 4.1 What Is a Round?
 
-A round is a **window of time** (3-7 days) covering multiple real matches. All players from those matches form the available pool.
+A round is an **admin-curated group of real matches** that form a single CM contest window. All players from those matches form the available pool. Rounds are hand-composed by an admin when they create a Mega League — they are *not* auto-windowed by date.
 
 ```
-Example: IPL Round 5
-├── Day 1: MI vs CSK     (Apr 10, 7:30pm)
-├── Day 2: RCB vs KKR    (Apr 11, 3:30pm)
-│          DC vs SRH     (Apr 11, 7:30pm)
-├── Day 3: GT vs PBKS    (Apr 12, 7:30pm)
-├── Day 4: LSG vs RR     (Apr 13, 3:30pm)
-│          MI vs DC      (Apr 13, 7:30pm)
-└── Day 5: CSK vs RCB    (Apr 14, 7:30pm)
+Example: IPL 2026 Mega League (admin-composed)
+├── Round 1 — "Opening Fixtures" (5 matches, one per team's first game)
+│     ├── RCB vs SRH    (Mar 28)
+│     ├── MI vs KKR     (Mar 29)
+│     ├── RR vs CSK     (Mar 30)
+│     ├── PBKS vs GT    (Mar 31)
+│     └── LSG vs DC     (Apr 1)
+├── Round 2 — "Second Fixtures" (5 matches)
+│     ├── KKR vs SRH    (Apr 2)
+│     ├── CSK vs PBKS   (Apr 3)
+│     ├── DC vs MI      (Apr 4)
+│     ├── GT vs RR      (Apr 4)
+│     └── SRH vs LSG    (Apr 5)
+├── Round 3 — "Third Fixtures" (5 matches)
+│     ...
+├── …
+└── Final Round — "IPL Final" (1 match)
 
-Player Pool: ~154 players across 7 matches
-Each member picks 11 from this pool
+Player Pool per round: players from that round's matches only
+Each member picks 11 from that pool, per round
 ```
+
+The admin decides how matches group together — typical pattern is **"each team plays once per round"** (so Round 1 = each team's first match, Round 2 = each team's second, etc.), with knockouts/finals as single-match rounds. But admin is free to group however they want (by date window, by stage, etc.).
 
 ### 4.2 Round Configuration
 
-| Field | Description | Default |
-|-------|-------------|---------|
-| `name` | Display name ("IPL Round 5") | Auto-generated |
-| `matchIds` | Array of match IDs in this window | Auto from schedule |
-| `windowStart` | First match start time | From schedule |
-| `windowEnd` | Last match estimated end | From schedule |
-| `lockTime` | When entries freeze | 30 min before first match |
+| Field | Description | Set By |
+|-------|-------------|--------|
+| `name` | Display name ("Round 1 — Opening Fixtures") | Admin |
+| `matchIds` | Array of match IDs hand-picked by admin | Admin |
+| `roundNumber` | Sequence within the mega league (1, 2, 3, …) | Admin |
+| `windowStart` | Earliest match start time | Derived from `matchIds` |
+| `windowEnd` | Latest match estimated end | Derived from `matchIds` |
+| `lockTime` | When entries freeze | Default: 30 min before first match (admin can override) |
 | `ballLimit` | Balls for simulation | 120 |
 | `minBowlers` | Min bowlers in squad | 5 |
-| `minWicketKeepers` | Min WKs in squad | 1 |
 | `maxOversPerBowler` | Bowling cap per bowler | 4 (24 balls) |
 
-### 4.3 Round Lifecycle
+### 4.3 Mega League (Admin-Created Parent)
+
+Rounds live inside a **Mega League** — a public, admin-created container that spans an entire tournament (e.g. "IPL 2026 Mega League"). The admin defines:
+
+| Field | Description |
+|-------|-------------|
+| `name` | Display name ("IPL 2026 Mega League") |
+| `tournamentId` | Tournament this league is tied to |
+| `visibility` | `public` (open to all users) — default for admin-created leagues |
+| `entryFee` | PC cost to join the mega league (one-time, covers all rounds) |
+| `prizePool` | Total guaranteed prize pool for the league |
+| `prizeDistribution` | How the pool splits across final season standings |
+| `roundPrizeSplit` | Optional per-round sub-pool (e.g. 10% of pool awarded per round, 50% held for finals) |
+| `maxMembers` | Cap on total members |
+| `createdBy` | Admin user ID |
+
+**Flow:**
+1. Admin creates Mega League for a tournament
+2. Admin composes Round 1 (picks matches, sets name, sets lock time)
+3. Admin composes Round 2, Round 3, … Final Round
+4. League opens for public joining. Users join once → automatically entered in every round
+5. Each round runs through its own lifecycle (upcoming → open → locked → live → settled)
+6. Season leaderboard = cumulative NRR across all settled rounds
+7. At tournament end, prize pool distributes per `prizeDistribution`
+
+> Admins can add/edit future rounds as the real tournament schedule firms up, but cannot modify a round once it has entered `locked` state.
+
+### 4.4 Round Lifecycle
 
 ```
 ┌───────────┐    ┌──────────┐    ┌──────────┐    ┌──────────┐    ┌──────────┐
@@ -361,7 +388,7 @@ Triggers:
 
 ---
 
-## 5. The 4 Phases of a Round
+## 5. The 3 Phases of a Round
 
 ### Phase 1: Squad Selection ("The Draft")
 
@@ -373,8 +400,9 @@ When: Round OPEN → lockTime
 - Select exactly **11 players**
 - **Validation:**
   - Exactly 11 players
-  - Min 1 wicket-keeper
   - Min 5 bowlers (bowler or all-rounder)
+
+> **No wicketkeeper requirement.** The simulation only scores batting runs and bowling figures — keeping (catches/stumpings/byes) isn't an input to either total, so a WK is functionally just a batter. No positional constraint on WKs.
 - Stats shown: Recent Strike Rate, Average, Economy, Bowling SR
 - **Why it's fun:** No budget → build your Dream XI. But every batter is a "ball resource" to manage.
 
@@ -396,18 +424,7 @@ When: Same as Phase 1 (tabs 2 & 3 of the entry builder)
 - Each bowler capped at 4 overs (24 balls) regardless of how much they bowled IRL
 - Visual aid: Economy Rate and Bowling SR next to each name
 
-### Phase 3: The Toss Call
-
-```
-When: Final step before submitting entry
-```
-
-- Binary choice: **Bat First** or **Bowl First**
-- Bat First: +5% to Batting Total
-- Bowl First: -5% to Bowling Total (reduction)
-- UI: Animated coin flip (cosmetic — user chooses, not random)
-
-### Phase 4: The Live Match
+### Phase 3: The Live Match
 
 ```
 When: LOCKED → LIVE → SETTLED (plays out over days)
@@ -436,7 +453,7 @@ This is what makes CM engaging. Members watch a multi-day race unfold:
 │  YOUR INTERNAL MATCH                                 │
 │  BAT  ━━━━━━━━━━━━━━━━━━━▓▓▓░░░  178               │
 │  BOWL ━━━━━━━━━━━━━━━░░░░░░░░░░  142               │
-│  NRR: +1.80    Bat First (+5%)   BATTING LEADS      │
+│  NRR: +1.80                      BATTING LEADS      │
 │                                                      │
 │  ─── CONTEST STANDINGS (LIVE) ────────────────────  │
 │  #1  CricketGuru    NRR +3.20  ▲  Bat:195 Bowl:131 │
@@ -514,21 +531,13 @@ Overs bowled: 14.0/20
 
 ### 7.1 NRR Formula
 
-The exact formula used for ranking:
+The exact formula used for ranking — mirrors real cricket ICC NRR:
 
 ```
-NRR = (Adjusted Batting Total / 20) - (Adjusted Bowling Total / 20)
+NRR = (Batting Total / 20) - (Bowling Total / 20)
 ```
 
-Where:
-- If toss = Bat First: Adjusted Batting = Raw Batting × 1.05, Adjusted Bowling = Raw Bowling
-- If toss = Bowl First: Adjusted Batting = Raw Batting, Adjusted Bowling = Raw Bowling × 0.95
-
-**Special case — all out (10 wickets lost in batting):**
-```
-Batting NRR = Adjusted Batting Total / (ballsUsed / 6)   ← actual overs, NOT 20
-```
-This penalizes getting "all out" — your batting run rate is divided by fewer overs, making it look better per-over but you scored fewer total runs because the innings ended early.
+Both innings always use the full 20-over allocation as the denominator. Per real NRR rules, if a team is bowled out, the full quota of overs is still used — so getting all out is naturally penalized by scoring fewer runs over the same 20 overs, not by changing the denominator.
 
 ### 7.2 Tie-Breakers
 
@@ -544,7 +553,6 @@ This penalizes getting "all out" — your batting run rate is divided by fewer o
 Per-contest ranking of all members by NRR. Shows:
 - Rank, username, NRR, batting total, bowling total
 - Rank movement arrows (up/down since last update) during live phase
-- Toss choice icon (bat/bowl)
 
 ### 7.4 Season Leaderboard
 
@@ -586,7 +594,7 @@ The engine needs these data points per player per match, all sourced from existi
 |-------|--------|----------|
 | `name` | `players.name` | Display |
 | `team` | `players.team` | Grouping / filtering |
-| `role` | `players.role` | Validation (min bowlers, min WK) |
+| `role` | `players.role` | Validation (min bowlers) |
 | `battingStyle` | `players.battingStyle` | Info display |
 | `bowlingStyle` | `players.bowlingStyle` | Info display |
 | `recentSR` | Derived from last 5 `playerMatchScores` | Batting order aid |
@@ -610,13 +618,52 @@ High-efficiency players for testing the engine:
 
 ## 9. Database Schema
 
-### 9.1 `cm_rounds` — A multi-match window
+### 9.0 `cm_mega_leagues` — Admin-created parent container
+
+```sql
+CREATE TABLE cm_mega_leagues (
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tournament_id       UUID NOT NULL REFERENCES tournaments(id),
+  name                TEXT NOT NULL,                 -- "IPL 2026 Mega League"
+  description         TEXT,
+  visibility          TEXT NOT NULL DEFAULT 'public',
+    -- public | private
+
+  -- Economics
+  entry_fee           INTEGER NOT NULL DEFAULT 0,    -- Pop Coins (one-time)
+  prize_pool          INTEGER NOT NULL DEFAULT 0,    -- Total guaranteed
+  prize_distribution  JSONB NOT NULL DEFAULT '[]',
+    -- Final season standings split
+  round_prize_split   JSONB NOT NULL DEFAULT '{}',
+    -- Optional per-round sub-pool config
+    -- { perRoundPct: 10, finalPct: 50 } → 10% of pool awarded per round, 50% held for finals
+
+  -- Capacity
+  max_members         INTEGER NOT NULL DEFAULT 10000,
+  current_members     INTEGER NOT NULL DEFAULT 0,
+
+  -- Status
+  status              TEXT NOT NULL DEFAULT 'draft',
+    -- draft | open | in_progress | settled | cancelled
+
+  created_by          UUID NOT NULL REFERENCES users(id),   -- Admin
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_cm_mega_leagues_tournament ON cm_mega_leagues(tournament_id);
+CREATE INDEX idx_cm_mega_leagues_status ON cm_mega_leagues(status);
+```
+
+### 9.1 `cm_rounds` — A hand-composed group of matches
 
 ```sql
 CREATE TABLE cm_rounds (
   id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  mega_league_id  UUID NOT NULL REFERENCES cm_mega_leagues(id) ON DELETE CASCADE,
   tournament_id   UUID NOT NULL REFERENCES tournaments(id),
-  name            TEXT NOT NULL,                    -- "IPL Round 5"
+  round_number    INTEGER NOT NULL,                 -- Sequence within mega league
+  name            TEXT NOT NULL,                    -- "Round 1 — Opening Fixtures"
   status          TEXT NOT NULL DEFAULT 'upcoming',
     -- upcoming | open | locked | live | settled | void
   format          TEXT NOT NULL DEFAULT 'standard',
@@ -635,9 +682,8 @@ CREATE TABLE cm_rounds (
   -- Config
   ball_limit              INTEGER NOT NULL DEFAULT 120,
   min_bowlers             INTEGER NOT NULL DEFAULT 5,
-  min_wicket_keepers      INTEGER NOT NULL DEFAULT 1,
   max_overs_per_bowler    INTEGER NOT NULL DEFAULT 4,
-  toss_bonus_pct          DECIMAL(4,2) NOT NULL DEFAULT 5.0,
+
   
   -- Progress
   matches_completed INTEGER NOT NULL DEFAULT 0,
@@ -652,8 +698,10 @@ CREATE TABLE cm_rounds (
   updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
+CREATE INDEX idx_cm_rounds_mega_league ON cm_rounds(mega_league_id);
 CREATE INDEX idx_cm_rounds_tournament ON cm_rounds(tournament_id);
 CREATE INDEX idx_cm_rounds_status ON cm_rounds(status);
+CREATE UNIQUE INDEX idx_cm_rounds_number ON cm_rounds(mega_league_id, round_number);
 ```
 
 ### 9.2 `cm_contests` — A group of members competing on a round
@@ -716,28 +764,22 @@ CREATE TABLE cm_entries (
   -- Bowling strategy (priority ranked)
   bowling_priority JSONB NOT NULL,
     -- [{priority: 1, playerId}, {priority: 2, playerId}, ...]
-  
-  -- Toss decision
-  toss_choice     TEXT NOT NULL DEFAULT 'bat_first',
-    -- 'bat_first' | 'bowl_first'
-  
+
   -- Chip (optional)
   chip_used       TEXT,
   chip_target     TEXT,
-  
+
   -- Simulation results (updated live, finalized on settlement)
   batting_total       INTEGER DEFAULT 0,
   batting_balls_used  INTEGER DEFAULT 0,
   batting_wickets     INTEGER DEFAULT 0,
   batting_details     JSONB,     -- Per-batter breakdown
-  
+
   bowling_total         INTEGER DEFAULT 0,
   bowling_balls_bowled  INTEGER DEFAULT 0,
   bowling_wickets       INTEGER DEFAULT 0,
   bowling_details       JSONB,   -- Per-bowler breakdown
-  
-  adjusted_batting    INTEGER DEFAULT 0,
-  adjusted_bowling    INTEGER DEFAULT 0,
+
   nrr                 DECIMAL(8,4) DEFAULT 0,
   batting_sr          DECIMAL(8,4) DEFAULT 0,
   
@@ -821,19 +863,23 @@ CREATE TABLE cm_chips (
 ```
 tournaments
   │
-  ├── cm_rounds (1:many — rounds per tournament)
+  ├── cm_mega_leagues (1:many — admin-created league parents)
   │     │
-  │     ├── cm_contests (1:many — multiple contests per round)
-  │     │     │
-  │     │     └── cm_contest_members (1:many — members in each contest)
-  │     │           │
-  │     │           └── references cm_entries (member's shared entry for the round)
+  │     ├── cm_mega_league_members (1:many — users who joined the league)
   │     │
-  │     └── cm_entries (1:many — one entry per user per round)
+  │     └── cm_rounds (1:many — admin-composed rounds)
   │           │
-  │           └── uses playerMatchScores (existing) for simulation
+  │           ├── cm_contests (1:many — contest buckets inside each round; public/private/H2H)
+  │           │     │
+  │           │     └── cm_contest_members (1:many — members in each contest)
+  │           │           │
+  │           │           └── references cm_entries (member's shared entry for the round)
+  │           │
+  │           └── cm_entries (1:many — one entry per user per round)
+  │                 │
+  │                 └── uses playerMatchScores (existing) for simulation
   │
-  ├── cm_season_standings (1:many — cumulative stats per user)
+  ├── cm_season_standings (1:many — cumulative stats per user per mega league)
   │
   └── cm_chips (1:many — chip inventory per user)
 
@@ -920,7 +966,6 @@ export const cricketManagerRouter = router({
         priority: z.number().min(1),
         playerId: z.string().uuid(),
       })).min(5),
-      tossChoice: z.enum(['bat_first', 'bowl_first']),
       chipUsed: z.string().optional(),
       chipTarget: z.string().optional(),
     }))
@@ -965,17 +1010,65 @@ export const cricketManagerRouter = router({
     .input(z.object({ tournamentId: z.string().uuid() }))
     .query(),
   
+  // ─── Mega Leagues (public, browsable by users) ──────────
+
+  listMegaLeagues: protectedProcedure
+    .input(z.object({ tournamentId: z.string().uuid().optional() }))
+    .query(),
+
+  getMegaLeague: protectedProcedure
+    .input(z.object({ megaLeagueId: z.string().uuid() }))
+    .query(),
+
+  joinMegaLeague: protectedProcedure
+    .input(z.object({ megaLeagueId: z.string().uuid() }))
+    .mutation(),  // Pays entry fee, auto-enters every round
+
   // ─── Admin ──────────────────────────────────────────────
-  
-  createRound: adminProcedure
+
+  createMegaLeague: adminProcedure
     .input(z.object({
       tournamentId: z.string().uuid(),
       name: z.string(),
-      matchIds: z.array(z.string().uuid()),
-      lockTime: z.date(),
+      description: z.string().optional(),
+      entryFee: z.number().int().nonnegative(),
+      prizePool: z.number().int().nonnegative(),
+      prizeDistribution: z.array(z.object({ rank: z.number(), percent: z.number() })),
+      roundPrizeSplit: z.object({
+        perRoundPct: z.number().optional(),
+        finalPct: z.number().optional(),
+      }).optional(),
+      maxMembers: z.number().int().positive().optional(),
     }))
     .mutation(),
-  
+
+  composeRound: adminProcedure
+    .input(z.object({
+      megaLeagueId: z.string().uuid(),
+      roundNumber: z.number().int().positive(),
+      name: z.string(),
+      matchIds: z.array(z.string().uuid()).min(1),
+      lockTime: z.date().optional(),
+    }))
+    .mutation(),
+
+  updateRound: adminProcedure
+    .input(z.object({
+      roundId: z.string().uuid(),
+      name: z.string().optional(),
+      matchIds: z.array(z.string().uuid()).optional(),
+      lockTime: z.date().optional(),
+    }))
+    .mutation(),  // Only allowed while round is 'upcoming'
+
+  deleteRound: adminProcedure
+    .input(z.object({ roundId: z.string().uuid() }))
+    .mutation(),  // Only allowed while round is 'upcoming'
+
+  publishMegaLeague: adminProcedure
+    .input(z.object({ megaLeagueId: z.string().uuid() }))
+    .mutation(),  // draft → open
+
   settleRound: adminProcedure
     .input(z.object({ roundId: z.string().uuid() }))
     .mutation(),
@@ -1000,24 +1093,20 @@ function validateEntry(input, round, playerPool) {
   // 4. No duplicates
   assert(new Set(input.players.map(p => p.playerId)).size === 11, 'No duplicates');
   
-  // 5. Min 1 WK
-  const wks = input.players.filter(p => getRole(p, playerPool) === 'wicket_keeper');
-  assert(wks.length >= 1, 'Need at least 1 WK');
-  
-  // 6. Min 5 bowlers
+  // 5. Min 5 bowlers
   const bowlers = input.players.filter(p => canBowl(p, playerPool));
   assert(bowlers.length >= 5, 'Need at least 5 bowlers');
-  
-  // 7. Batting order = all 11, positions 1-11
+
+  // 6. Batting order = all 11, positions 1-11
   assert(input.battingOrder.length === 11, 'Batting order must have 11');
   const positions = new Set(input.battingOrder.map(b => b.position));
   assert(positions.size === 11, 'Positions 1-11 required');
-  
-  // 8. Bowling priority: all bowlers from squad ranked
+
+  // 7. Bowling priority: all bowlers from squad ranked
   const bowlerIds = new Set(bowlers.map(b => b.playerId));
   input.bowlingPriority.forEach(b => assert(bowlerIds.has(b.playerId), 'Not a bowler'));
-  
-  // 9. Chip validation (if used)
+
+  // 8. Chip validation (if used)
   if (input.chipUsed) validateChip(input, round);
 }
 ```
@@ -1072,11 +1161,10 @@ Cricket Manager tab (bottom nav or section)
 │   ├── Recent results
 │   └── Season standings mini
 │
-├── Entry Builder (3 tabs + toss)
+├── Entry Builder (3 tabs)
 │   ├── Tab 1: Squad Selection
 │   ├── Tab 2: Batting Order (drag & drop)
-│   ├── Tab 3: Bowling Priority (drag & drop)
-│   └── Toss Call (bat first / bowl first)
+│   └── Tab 3: Bowling Priority (drag & drop)
 │
 ├── Contest Browser
 │   ├── Public contests for current round
@@ -1105,19 +1193,17 @@ Cricket Manager tab (bottom nav or section)
 ```
 ┌─────────────────────────────────────────────────────┐
 │  BUILD YOUR XI              IPL Week 5 │ 7 matches │
-│  ─── Squad ─── Batting ─── Bowling ─── Toss ──────│
+│  ─── Squad ─── Batting ─── Bowling ───────────────│
 │─────────────────────────────────────────────────────│
 │  🔍 Search...                   Filter: All ▾      │
-│  Selected: 8/11 │ Bowlers: 4/5 min │ WK: 1 ✓      │
+│  Selected: 8/11 │ Bowlers: 4/5 min                 │
 │─────────────────────────────────────────────────────│
-│  WICKET-KEEPERS                                     │
-│  ☑ R Pant       DC    SR: 155   Avg: 35            │
-│  ☐ KL Rahul     LSG   SR: 128   Avg: 42            │
-│                                                     │
 │  BATSMEN                                            │
 │  ☑ V Kohli      RCB   SR: 142   Avg: 48            │
 │  ☑ S Gill       GT    SR: 138   Avg: 42            │
 │  ☑ A Sharma     SRH   SR: 190   Avg: 28            │
+│  ☑ R Pant       DC    SR: 155   Avg: 35            │
+│  ☐ KL Rahul     LSG   SR: 128   Avg: 42            │
 │                                                     │
 │  ALL-ROUNDERS                                       │
 │  ☑ H Pandya     MI    SR: 148   Econ: 8.5          │
@@ -1138,7 +1224,7 @@ Cricket Manager tab (bottom nav or section)
 ```
 ┌─────────────────────────────────────────────────────┐
 │  BATTING ORDER                                      │
-│  ─── Squad ─── Batting ─── Bowling ─── Toss ──────│
+│  ─── Squad ─── Batting ─── Bowling ───────────────│
 │─────────────────────────────────────────────────────│
 │  Drag to reorder. High SR at top = more runs.       │
 │─────────────────────────────────────────────────────│
@@ -1165,7 +1251,7 @@ Cricket Manager tab (bottom nav or section)
 ```
 ┌─────────────────────────────────────────────────────┐
 │  BOWLING PRIORITY                                   │
-│  ─── Squad ─── Batting ─── Bowling ─── Toss ──────│
+│  ─── Squad ─── Batting ─── Bowling ───────────────│
 │─────────────────────────────────────────────────────│
 │  Rank bowlers by priority. Best economy at top.     │
 │  Each bowler capped at 4 overs (24 balls).          │
@@ -1186,28 +1272,7 @@ Cricket Manager tab (bottom nav or section)
 └─────────────────────────────────────────────────────┘
 ```
 
-### 11.5 Toss Call
-
-```
-┌─────────────────────────────────────────────────────┐
-│  YOUR TOSS CALL                                     │
-│  ─── Squad ─── Batting ─── Bowling ─── Toss ──────│
-│─────────────────────────────────────────────────────│
-│                                                     │
-│       ┌───────────────┐    ┌───────────────┐        │
-│       │  BAT FIRST    │    │  BOWL FIRST   │        │
-│       │               │    │               │        │
-│       │  +5% Batting  │    │  -5% Bowling  │        │
-│       │  Total        │    │  Total        │        │
-│       └───────────────┘    └───────────────┘        │
-│                                                     │
-│  Your squad: 3 elite batters, 4 strong bowlers      │
-│                                                     │
-│                               [Submit Entry]        │
-└─────────────────────────────────────────────────────┘
-```
-
-### 11.6 Contest Browser
+### 11.5 Contest Browser
 
 ```
 ┌─────────────────────────────────────────────────────┐
@@ -1240,58 +1305,91 @@ Cricket Manager tab (bottom nav or section)
 
 ## 12. Data Pipeline Integration
 
-### 12.1 Auto-Create Rounds
+### 12.1 Admin-Create Mega League & Rounds
+
+Rounds are **not auto-generated**. An admin composes the mega league and its rounds manually through the admin portal. The system then manages lifecycle transitions automatically.
 
 ```typescript
-// Runs when tournament schedule is refreshed
+// Admin flow — called from admin portal
 
-async function autoCreateRounds(tournamentId: string) {
-  const matches = await getUpcomingMatches(tournamentId);
-  const windows = groupMatchesIntoWindows(matches, { windowDays: 5 });
-  
-  for (const window of windows) {
-    const existing = await findExistingRound(tournamentId, window.matchIds);
-    if (existing) continue;
-    
-    await db.insert(cmRounds).values({
-      tournamentId,
-      name: `${tournament.name} Round ${window.number}`,
-      matchIds: window.matchIds,
-      windowStart: window.firstMatchTime,
-      windowEnd: window.lastMatchEndEstimate,
-      lockTime: subMinutes(window.firstMatchTime, 30),
-      matchesTotal: window.matchIds.length,
-    });
-    
-    // Auto-create public contests for this round
-    await createDefaultContests(round.id);
-  }
+async function createMegaLeague(adminUserId: string, input: CreateMegaLeagueInput) {
+  assertAdmin(adminUserId);
+
+  const league = await db.insert(cmMegaLeagues).values({
+    tournamentId: input.tournamentId,
+    name: input.name,                        // "IPL 2026 Mega League"
+    description: input.description,
+    visibility: 'public',
+    entryFee: input.entryFee,
+    prizePool: input.prizePool,
+    prizeDistribution: input.prizeDistribution,
+    roundPrizeSplit: input.roundPrizeSplit,  // Optional per-round sub-pool config
+    maxMembers: input.maxMembers ?? 10000,
+    status: 'draft',
+    createdBy: adminUserId,
+  }).returning();
+
+  return league;
 }
 
-async function createDefaultContests(roundId: string) {
-  // Mega contest (large, low entry fee)
-  await db.insert(cmContests).values({
-    roundId, name: 'Mega Contest', contestType: 'mega',
-    entryFee: 20, maxMembers: 1000, isGuaranteed: true,
-    prizePool: 15000,
-    prizeDistribution: MEGA_PRIZE_TABLE,
-  });
-  
-  // Small stakes
-  await db.insert(cmContests).values({
-    roundId, name: 'Small Stakes', contestType: 'public',
-    entryFee: 10, maxMembers: 100,
-    prizeDistribution: SMALL_PRIZE_TABLE,
-  });
-  
-  // Free practice
-  await db.insert(cmContests).values({
-    roundId, name: 'Free Practice', contestType: 'free',
-    entryFee: 0, maxMembers: 50, prizePool: 100,
-    prizeDistribution: FREE_PRIZE_TABLE,
-  });
+async function composeRound(adminUserId: string, input: ComposeRoundInput) {
+  assertAdmin(adminUserId);
+
+  const league = await getMegaLeague(input.megaLeagueId);
+  assert(league.status === 'draft' || league.status === 'open',
+    'Cannot add rounds to an in-progress or settled league');
+
+  // Admin picks which matches belong to this round
+  const matches = await getMatchesByIds(input.matchIds);
+  assert(matches.length === input.matchIds.length, 'Invalid match IDs');
+  assert(matches.every(m => m.tournamentId === league.tournamentId),
+    'All matches must belong to the league tournament');
+
+  // Derive window from selected matches
+  const windowStart = min(matches.map(m => m.startTime));
+  const windowEnd   = max(matches.map(m => m.estimatedEndTime));
+  const lockTime    = input.lockTime ?? subMinutes(windowStart, 30);
+
+  const round = await db.insert(cmRounds).values({
+    megaLeagueId: league.id,
+    tournamentId: league.tournamentId,
+    roundNumber: input.roundNumber,
+    name: input.name,                        // "Round 1 — Opening Fixtures"
+    matchIds: input.matchIds,
+    windowStart,
+    windowEnd,
+    lockTime,
+    matchesTotal: input.matchIds.length,
+    status: 'upcoming',
+  }).returning();
+
+  return round;
+}
+
+async function publishMegaLeague(adminUserId: string, megaLeagueId: string) {
+  assertAdmin(adminUserId);
+  const league = await getMegaLeague(megaLeagueId);
+  assert(league.status === 'draft', 'League already published');
+
+  const rounds = await getRounds(megaLeagueId);
+  assert(rounds.length >= 1, 'League must have at least one round');
+
+  await db.update(cmMegaLeagues)
+    .set({ status: 'open' })
+    .where(eq(cmMegaLeagues.id, megaLeagueId));
 }
 ```
+
+**Lifecycle automation (system-managed, not admin):**
+- When a round's `windowStart - 30min` is reached → `upcoming → open` (player pool populated from squads)
+- When `lockTime` is reached → `open → locked`
+- When first match starts → `locked → live`
+- When all matches in `matchIds` are final → `live → settled` (triggers settlement, updates season standings)
+
+**Editing rules:**
+- Admin can add, edit, or delete `upcoming` rounds freely
+- Once a round transitions to `locked`, its `matchIds` and config are immutable
+- Admin cannot delete a mega league that has any round past `upcoming`
 
 ### 12.2 Live Score Hook
 
@@ -1388,7 +1486,7 @@ DraftPlay App
 ├── 🆕 Cricket Manager ←── Standalone mode
 │     ├── Round Hub
 │     ├── Contest Browser
-│     ├── Entry Builder (3 tabs + toss)
+│     ├── Entry Builder (3 tabs)
 │     ├── Live Match View
 │     ├── Results & Reveal
 │     └── Season Dashboard
@@ -1459,7 +1557,6 @@ Live predictions can overlay on CM rounds:
 | Tactician | Top 10% in a contest |
 | Bowling Masterclass | Bowling takes 10 wickets |
 | Season Champion | #1 in season standings |
-| Coin Flip King | Optimal toss choice 5 rounds in a row |
 
 ### 13.8 Guru AI
 
@@ -1467,7 +1564,7 @@ Live predictions can overlay on CM rounds:
 |---------|------|---------|
 | Rate My XI | Pro+ | "Strong batting, weak death bowling" |
 | Order Suggestion | Elite | AI-optimized batting order |
-| Toss Advice | Pro+ | "Bat First gives +12% expected NRR" |
+| Bowling Priority Advice | Pro+ | "Open with Bumrah, save Rashid for middle overs" |
 
 ---
 
@@ -1514,7 +1611,7 @@ One of each per tournament. Once used, gone.
 | Scenario | Rule |
 |----------|------|
 | All batters DNB | Batting total = 0. Heavy negative NRR. |
-| All out (10 wickets) | Batting NRR uses actual overs as denominator. |
+| All out (10 wickets) | Batting innings ends early. Denominator stays at 20 overs (real NRR rule) — fewer total runs = lower NRR. |
 | Bowlers don't cover 120 balls | Remaining balls = 0 conceded (benefits user). |
 | NRR tie | Batting SR tie-breaker. |
 
@@ -1535,12 +1632,13 @@ One of each per tournament. Once used, gone.
 
 | Task | Files |
 |------|-------|
-| DB schema (cm_rounds, cm_contests, cm_entries, cm_contest_members) | `packages/db/src/schema/cricket-manager.ts` |
-| 120-ball engine (batting + bowling + toss + lethality) | `packages/api/src/services/cm-engine.ts` |
-| Round manager (auto-create, open, lock, settle) | `packages/api/src/services/cm-round-manager.ts` |
-| tRPC router (rounds, contests, entries, leaderboard) | `packages/api/src/routers/cricket-manager.ts` |
+| DB schema (cm_mega_leagues, cm_rounds, cm_contests, cm_entries, cm_contest_members) | `packages/db/src/schema/cricket-manager.ts` |
+| 120-ball engine (batting + bowling + lethality) | `packages/api/src/services/cm-engine.ts` |
+| Round manager (lifecycle transitions, settlement) | `packages/api/src/services/cm-round-manager.ts` |
+| tRPC router (mega leagues, rounds, contests, entries, leaderboard) | `packages/api/src/routers/cricket-manager.ts` |
+| Admin mega-league composer (create league, compose rounds, publish) | `apps/web/app/admin/cricket-manager/` |
 | Contest creation + join + prize distribution | `packages/api/src/services/cm-contest.ts` |
-| Entry builder UI (3 tabs + toss) | `apps/mobile/app/cricket-manager/` |
+| Entry builder UI (3 tabs) | `apps/mobile/app/cricket-manager/` |
 | Contest browser UI | `apps/mobile/app/cricket-manager/contests/` |
 | Round leaderboard UI | Reuse leaderboard components |
 | Score-updater hook for live updates | `packages/api/src/jobs/score-updater.ts` |
@@ -1571,7 +1669,7 @@ One of each per tournament. Once used, gone.
 | Task | Details |
 |------|---------|
 | Subscription tier gating | Free/Pro/Elite feature gates |
-| Guru AI integration | Rate XI, suggest order, toss advice |
+| Guru AI integration | Rate XI, suggest batting order, suggest bowling priority |
 | "What If" analysis | Post-round optimization |
 | Round variants | Powerplay, Death Overs |
 | H2H contests | Direct 1v1 duels |
@@ -1586,8 +1684,7 @@ One of each per tournament. Once used, gone.
 **Contest:** Mega Contest (342 members, 20 PC entry, 15,000 PC pool)
 
 **Member "You":**
-- Squad: Kohli, Gill, Pant(WK), Pandya(AR), Jadeja(AR), Ishan, Bumrah, Shami, Chahal, Rashid, Chahar
-- Toss: Bat First (+5%)
+- Squad: Kohli, Gill, Pant, Pandya(AR), Jadeja(AR), Ishan, Bumrah, Shami, Chahal, Rashid, Chahar
 
 ### Aggregated Real Stats
 
@@ -1633,17 +1730,251 @@ One of each per tournament. Once used, gone.
 ### Result
 
 ```
-Toss: Bat First → Batting × 1.05
-Adjusted Batting: 190 × 1.05 = 199
-Adjusted Bowling: 136
+Batting Total: 190
+Bowling Total: 136
 
-NRR = (199/20) - (136/20) = 9.95 - 6.80 = +3.15
+NRR = (190/20) - (136/20) = 9.50 - 6.80 = +2.70
 Batting SR = (190/120) × 100 = 158.33
 
-Contest Rank: #3 of 342 → Won 200 PC
+Contest Rank: #5 of 342 → Won 150 PC
 ```
 
-**Why #3?** Members #1 and #2 found better batting orders — they put Abhishek Sharma (SR: 190) at #1 instead of Kohli, freeing up more balls for the middle order. Same concept, different strategy, different result. That's Cricket Manager.
+**Why #5?** Members ranked above you found better batting orders — they put Abhishek Sharma (SR: 190) at #1 instead of Kohli, freeing up more balls for the middle order. Same concept, different strategy, different result. That's Cricket Manager.
+
+---
+
+## Appendix A — Known Loopholes & Edge Cases (Revisit Later)
+
+This appendix catalogs loopholes in the engine that remain under the current admin convention: **one match per player per round (N=1)**. Several of the original concerns (mega-player match-count concentration, binary dismissal flag, round-wide 4-over cap mismatch, linear bowling smoothing, wicket rounding at share<1) are naturally eliminated by the N=1 rule and are not included here. What follows is the residual list, ordered by severity.
+
+### Loophole #1 — Dead bowler / DNB quota fraud (**✅ FIXED 2026-04-13**)
+
+**Where:** [packages/api/src/services/cm-engine.ts:135](packages/api/src/services/cm-engine.ts#L135) and [:260](packages/api/src/services/cm-engine.ts#L260)
+
+**Original mechanism:** Two engine behaviors colluded:
+- Batters with `ballsFaced === 0 && runs === 0` were silently skipped (no slot cost).
+- Bowlers with `realBalls === 0` were silently skipped (no priority cost).
+- The "min 5 bowlers" rule checked the pick's role tag, not actual match participation.
+- NRR divided by a fixed 20 overs regardless of how many balls were actually bowled.
+
+**Original exploit:** Pick 3 real bowlers + 2 token "bowlers" from teams with deep attacks where the 7th/8th bowlers reliably don't bowl. The 2 tokens contribute zero runs conceded, but the bowling denominator stays at 20 overs — creating ~48 "free dot balls" worth of NRR. Measured swing: **+3.15 NRR** for zero effort.
+
+#### The fix we shipped
+
+We rejected a settlement-time validator (punitive, false positives on injuries, binary rejection) and fixed the underlying **asymmetry** instead. The root cause wasn't ghost bowlers — it was that short batting was naturally penalized (fewer runs against a fixed 20-over denominator) while short bowling was *rewarded* by the same denominator. Two complementary mechanisms now close both exits:
+
+**1. Phantom-fill (`bat_first` only)** — when `simulateBowling` runs with `applyPhantomFill = true` and the real bowling innings ends with unused balls remaining *and* fewer than 10 wickets, the gap is filled with notional runs at the round's own average ER:
+
+```ts
+// packages/api/src/services/cm-engine.ts
+if (
+  applyPhantomFill &&
+  ballsBowled < ballLimit &&
+  wickets < 10 &&
+  config.phantomFillER !== undefined &&
+  config.phantomFillER > 0
+) {
+  const phantomBalls = ballLimit - ballsBowled;
+  const phantomOvers = phantomBalls / BALLS_PER_OVER;
+  const phantomRuns = Math.round(phantomOvers * config.phantomFillER);
+  total += phantomRuns;
+  ballsBowled = ballLimit;
+  phantomApplied = true;
+}
+```
+
+The `wickets < 10` guard preserves lethality — a legitimate bowling-out still gets full credit for the short innings. Phantom fill only closes gaps from *missing* bowling capacity.
+
+**2. Round-average ER is computed from the round's own match data** — not a hardcoded constant. Added `computeRoundAvgER` in [packages/api/src/services/cm-service.ts](packages/api/src/services/cm-service.ts) which sums runs conceded and balls bowled across every real bowler in every match of the round. Self-calibrates to batting-paradise vs bowler-friendly conditions. Fallback of 8.5 ER only used when no real bowling data exists (e.g. before match 1 starts).
+
+**3. `runEntrySimulation` threads `phantomFillER` into `RoundConfig`** — every sim call now computes the round's avg ER and passes it through. No hardcoded league constants anywhere.
+
+#### Round 5 before vs after (using the user's own data)
+
+| | Before fix | After fix |
+|---|---|---|
+| Real balls bowled | 65 | 65 |
+| Real runs conceded | 82 | 82 |
+| Phantom balls | 0 | 55 (9.1 overs) |
+| Round avg ER | — | ~9.5 (high-scoring round) |
+| Phantom runs | 0 | round(9.1 × 9.5) = **87** |
+| Total bowling runs | 82 | **169** |
+| Final NRR | **+6.65** | **+2.30** |
+
+The fake cushion disappears. The user still wins on genuine batting (215 runs is real), but the ghost bowlers no longer contribute free "dot balls" to the denominator.
+
+#### Why this is strictly better than a validator
+
+| Concern | Validator approach | Phantom-fill approach |
+|---|---|---|
+| Injured bowler (1 real over) | Voids entire entry ❌ | Small penalty proportional to gap ✅ |
+| Ghost bowler exploit | Rejects | Mathematically nullifies the edge ✅ |
+| User experience | "Your entry was voided" | Normal settlement, just lower NRR ✅ |
+| Detects partial shortness | Binary detection only | Linear penalty ✅ |
+| False positive rate | High | Zero ✅ |
+
+#### Regression tests added
+
+In [tests/unit/cm-engine.test.ts](tests/unit/cm-engine.test.ts):
+- `phantom-fill: 5 real 4-over bowlers pay zero penalty (honest baseline)` — ensures honest entries pay nothing
+- `phantom-fill: ghost bowler cheater gets charged at round-avg ER (bat_first)` — reproduces the exploit with exact numbers
+- `phantom-fill: NOT triggered when bowling-out (wickets >= 10)` — preserves lethality rule
+
+---
+
+### Loophole #2 — `bat_first` is strictly dominant (**✅ FIXED 2026-04-13**)
+
+**Where:** [packages/api/src/services/cm-engine.ts:307-327](packages/api/src/services/cm-engine.ts#L307-L327)
+
+**Original mechanism:** NRR = `batting/20 - bowling/20` with **both** divisors fixed at 20 overs. `bowl_first` capped the batting numerator (chase target) but left the denominator the same, guaranteeing a lower NRR. There was no scenario where `bowl_first` produced a strictly better NRR than `bat_first`.
+
+#### The fix we shipped
+
+Fixed in the same patch as #1 — the two loopholes shared a root cause (the 20/20 denominator model). `bowl_first` now uses **actual-overs denominators** (rate-based), while `bat_first` keeps the 20/20 baseline with phantom fill. This is ICC-aligned: the chasing side in real cricket is scored on actual overs faced, which is exactly what the user pointed out in the original NRR conversation.
+
+```ts
+// packages/api/src/services/cm-engine.ts — simulateEntry
+if (toss === "bowl_first") {
+  // Risk play: real bowling innings (no phantom fill) then chase.
+  // Rate-based denominators reward fast chases and punish short bowling.
+  bowling = simulateBowling(entry, statsByPlayerId, config, false);
+  batting = simulateBatting(entry, statsByPlayerId, config, bowling.total + 1);
+  const battingOvers = batting.chaseComplete
+    ? batting.ballsUsed / BALLS_PER_OVER
+    : OVERS_PER_INNINGS; // failed chase → ICC full-allocation penalty
+  const bowlingOvers =
+    bowling.ballsBowled > 0 ? bowling.ballsBowled / BALLS_PER_OVER : OVERS_PER_INNINGS;
+  nrr = computeNrr(batting.total, bowling.total, battingOvers, bowlingOvers);
+} else {
+  // Safe baseline: freeroll batting + phantom-filled bowling, 20 / 20 denominators.
+  bowling = simulateBowling(entry, statsByPlayerId, config, true);
+  batting = simulateBatting(entry, statsByPlayerId, config);
+  nrr = computeNrr(batting.total, bowling.total);
+}
+```
+
+`computeNrr` now accepts optional `battingOvers` and `bowlingOvers` parameters that default to 20. A failed chase in `bowl_first` falls back to a 20-over batting denominator (ICC's all-out rule equivalent), so `bowl_first` becomes a genuine risk/reward lever: commit to a chase and get rate-based rewards, or fail the chase and eat the full-allocation penalty.
+
+#### Two modes, two legitimate strategies
+
+| Scenario | `bat_first` NRR | `bowl_first` NRR | Winner |
+|---|---|---|---|
+| Low bowling + efficient chase (100r bowled, 101-target chased fast) | moderate | **higher rate** | bowl_first |
+| High bowling + long slow batting (worked example: 190 vs 136) | **+2.70** | +2.44 | bat_first |
+| Failed chase (batting can't reach target) | safe baseline | **−2.00 penalty** | bat_first |
+
+The toss mechanic now has real consequences. Neither mode strictly dominates — choice matters.
+
+#### Regression tests added
+
+- `bowl_first fast chase: rate-based denominators reward efficient chase` — proves bowl_first can beat bat_first
+- `bowl_first failed chase: falls back to 20-over batting denominator` — proves the failed-chase penalty fires
+- `toss bowl_first: batters stop when chase target reached (rate-based denominators)` — existing test updated: NRR now **+2.436** instead of the broken +0.05
+
+---
+
+### Loophole #3 — Chase-mode mid-round NRR preview is mathematically wrong (UX bug)
+
+**Where:** [packages/api/src/services/cm-engine.ts:307-327](packages/api/src/services/cm-engine.ts#L307-L327)
+
+**Mechanism:** `simulateEntry` runs `simulateBowling` first, then (for `bowl_first`) runs `simulateBatting` with `target = bowling.total + 1`. During a **live** round, `bowling.total` is a running partial that will change at settlement.
+
+**Example:** Round 5 state — bowling total so far = 45 (4 of 5 matches done).
+
+User A (bat_first) and User B (bowl_first) pick identical 11 players.
+
+- **User A preview:** NRR = `205/20 - 45/20 = +8.00` ✅
+- **User B preview:** chase target = 46, batters stop at Rohit's 16th run → `NRR = 46/20 - 45/20 = +0.05` ❌
+
+User B panics seeing +0.05. But at settlement, final bowling total will be (say) 140, target becomes 141, and their real NRR is a totally different number. The preview has shown a **meaningless** value based on a target that won't exist at settlement.
+
+**Fix options:**
+
+1. **Skip chase during live preview:**
+   ```ts
+   const isLive = round.status === "live";
+   const toss = isLive ? "bat_first" : entry.toss;
+   ```
+   With disclaimer: *"Live projection — toss applied at settlement."*
+2. **Show both bounds:** Display both `bat_first` NRR and `bowl_first` NRR with a note.
+
+**Severity:** Low for correctness (settlement math is fine). High for UX trust — users seeing preview jump from +0.05 to +X.XX at settlement will assume the engine is broken.
+
+---
+
+### Loophole #4 — Partial-status dismissal escape (cosmetic under N=1)
+
+**Where:** [packages/api/src/services/cm-engine.ts:191-192](packages/api/src/services/cm-engine.ts#L191-L192)
+```ts
+const dismissedThisSlot = stats.dismissed && status === "full" && !stoppedByChase;
+```
+
+**Mechanism:** A real-life dismissal in a slot that got cut short by the 120-ball budget (`status: "partial"`) is silently discarded from the wicket count.
+
+**Honest assessment under N=1:** After a partial slot, `ballsUsed === ballLimit` exactly, so every subsequent slot becomes `didnt_bat`. This means the fix **never changes `total`, never changes `ballsUsed`**, so it **never changes NRR or SR**. The only thing affected is the `wickets` number in the returned payload, which is a display field.
+
+**Fix (1-line change):**
+```ts
+const dismissedThisSlot = stats.dismissed && !stoppedByChase;
+```
+
+**Why fix it anyway:**
+- Prevents regression if N ever increases (the loophole reactivates with full force under multi-match rounds)
+- Correctness for any future tiebreaker or display that reads `wickets`
+- 1-line change, zero risk
+
+**Severity under N=1:** Zero exploit value. Fix for code hygiene, not for balance.
+
+---
+
+### Loophole #5 — Budget-wall bowling rounding (corner case)
+
+**Where:** [packages/api/src/services/cm-engine.ts:263-271](packages/api/src/services/cm-engine.ts#L263-L271)
+
+**Mechanism:** When priorities 1–5 don't fully consume the 120-ball budget and a 6th+ bowler spills into the remainder, `share = remainingBudget / realBalls < 1` and `wicketsTaken = Math.round(stats.wickets × share)` can round a real wicket down to zero.
+
+**Example:** Priorities 1–5 use 100 balls. Bowler #6 Jadeja 4-0-36-4 (24 real balls) spills into the remaining 20 balls.
+- `share = 20/24 = 0.833`
+- `wicketsTaken = round(4 × 0.833) = round(3.33) = 3`
+
+One wicket vanished. If preserved, cumulative wickets would reach 10 → lethality stop triggers → bowling innings ends ~15 balls earlier → bowling total ~23 runs lower → NRR better by ~1.15.
+
+**Trigger conditions (all must hold):**
+1. Priority list has 6+ bowlers (most entries have exactly 5)
+2. Priorities 1–5 don't fully use the 120-ball budget (requires short spells — rain, early finish)
+3. A wicket-rich bowler sits in the spillover position
+
+Combined probability: ~5–10% of entries.
+
+**Fix options:**
+
+1. **Fractional wicket tracking:**
+   ```ts
+   cumulativeFractionalWickets += stats.wickets * share;
+   const wicketsTaken = Math.floor(cumulativeFractionalWickets) - previouslyCounted;
+   ```
+2. **Count real wickets against the 10-wicket gate** (conceded runs still scaled):
+   ```ts
+   wickets = Math.min(10, wickets + stats.wickets);
+   ```
+
+**Severity:** Low in typical cases, medium in corners. Not exploitable deterministically under N=1.
+
+---
+
+### Summary & status
+
+| # | Loophole | NRR impact | Exploitable? | Status |
+|---|---|---|---|---|
+| 1 | Dead bowler / DNB quota fraud | +2 to +4 per round | **Yes, deterministically** | **✅ FIXED 2026-04-13** — phantom-fill at round-avg ER |
+| 2 | `bat_first` dominance | +2 to +3 for informed users | No (dominant strategy) | **✅ FIXED 2026-04-13** — rate-based denominators for `bowl_first` |
+| 3 | Chase preview mid-round | Zero (display only) | No | Open — UI label only |
+| 4 | Partial dismissal escape | Zero under N=1 | No | Open — 1 line hygiene fix |
+| 5 | Budget-wall rounding | +1 to +1.5 in ~5–10% of entries | Mild | Open — ~3 lines |
+
+**The 2026-04-13 patch closed loopholes #1 and #2 together** via a single root-cause fix: the 20/20 NRR denominator model was the shared bug. `bat_first` now applies phantom-fill (computed from the round's own avg ER) to close the ghost-bowler exploit; `bowl_first` uses ICC-style rate-based denominators (actual overs for successful chases, 20-over fallback for failed chases) to revive the toss mechanic. Both fixes land in [packages/api/src/services/cm-engine.ts](packages/api/src/services/cm-engine.ts) and [packages/api/src/services/cm-service.ts](packages/api/src/services/cm-service.ts) with 5 new regression tests in [tests/unit/cm-engine.test.ts](tests/unit/cm-engine.test.ts). The 3 remaining loopholes (#3, #4, #5) are all low-impact and can ship post-launch.
+
+**Dependency on N=1:** This analysis assumes admins always compose rounds so that each player appears in exactly one match. If that convention changes, re-read Appendix A in full — loopholes originally covered by N=1 (mega-player concentration, binary dismissal flag, 4-over cap mismatch) reactivate with severity scaling in N.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "db:local": "./scripts/local-db.sh start",
     "db:local:stop": "./scripts/local-db.sh stop",
     "db:local:psql": "./scripts/local-db.sh psql",
-    "expo:prod": "cd apps/mobile && cp ../../.env.expo-prod .env.local.bak && cp ../../.env.expo-prod .env.local && npx expo start --clear; mv .env.local.bak .env.local",
+    "emulator": "npx firebase emulators:start --only auth --project demo-draftcrick",
+    "dev:all": "npx concurrently --names emu,api,web,app --prefix-colors yellow,cyan,magenta,green \"pnpm emulator\" \"sleep 2 && pnpm --filter @draftplay/api dev\" \"sleep 2 && pnpm --filter @draftplay/web dev\" \"sleep 4 && pnpm --filter @draftplay/mobile dev\"",
+    "expo:prod": "cd apps/mobile && cp .env.local .env.local.bak && cp ../../.env.expo-prod .env.local && trap 'mv .env.local.bak .env.local' EXIT && npx expo start --clear",
     "test:emulator": "node scripts/test-with-emulator.js",
     "test:type-check": "turbo type-check",
     "test:regression": "node scripts/test-regression.js",
@@ -43,6 +45,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
+    "concurrently": "^9.2.1",
     "pixelmatch": "^5.3.0",
     "pngjs": "^7.0.0",
     "turbo": "^2.3.0",

--- a/packages/api/src/jobs/score-updater.ts
+++ b/packages/api/src/jobs/score-updater.ts
@@ -8,6 +8,10 @@ import {
 } from "@draftplay/db";
 import { calculateFantasyPoints, DEFAULT_T20_SCORING } from "@draftplay/shared";
 import { updateContestRanks } from "../services/leaderboard";
+import {
+  onMatchScoreUpdate as cmOnMatchScoreUpdate,
+  tickRoundLifecycles as cmTickRoundLifecycles,
+} from "../services/cm-service";
 
 /**
  * Score updater job.
@@ -127,6 +131,22 @@ export async function processScoreUpdate(
 
     // Update contest ranks
     await updateContestRanks(db, contest.id);
+  }
+
+  // Cricket Manager: re-simulate all live CM entries touching this match,
+  // then run a lifecycle reconciliation pass so any CM rounds drifting out
+  // of sync with their match states (e.g. open but matches completed) get
+  // flipped automatically. Errors are swallowed — score update must not
+  // block on CM.
+  try {
+    await cmOnMatchScoreUpdate(db, matchId);
+  } catch {
+    // logged inside cm-service
+  }
+  try {
+    await cmTickRoundLifecycles(db);
+  } catch {
+    // logged inside cm-service
   }
 }
 

--- a/packages/api/src/routers/admin.ts
+++ b/packages/api/src/routers/admin.ts
@@ -21,8 +21,12 @@ import {
   dataRefreshLog,
   adminConfig,
   draftRooms,
+  leagues,
+  leagueMembers,
   getDb,
 } from "@draftplay/db";
+import { randomBytes } from "crypto";
+import { createLeagueSchema } from "@draftplay/shared";
 import { eq, desc, asc, sql, and, ilike, count, inArray } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import {
@@ -54,7 +58,11 @@ import type { Sport } from "@draftplay/shared";
 import { determineMatchPhase, calculateNextRefreshAfter, calculateFantasyPoints, DEFAULT_T20_SCORING, DEFAULT_SQUAD_RULES } from "@draftplay/shared";
 import { lockMatchContests, processScoreUpdate, completeMatch } from "../jobs/score-updater";
 import { settleMatchContests } from "../jobs/settle-contest";
-import { onPhaseTransition, finalizePredictionsAndSettle } from "../services/match-lifecycle";
+import {
+  applyMatchPhaseChange,
+  onPhaseTransition,
+  finalizePredictionsAndSettle,
+} from "../services/match-lifecycle";
 
 const log = getLogger("admin-router");
 
@@ -401,14 +409,16 @@ const matchesRouter = router({
     .input(
       z.object({
         tournamentId: z.string().uuid().optional(),
+        tournament: z.string().optional(),
         status: z.string().optional(),
-        limit: z.number().min(1).max(100).default(50),
+        limit: z.number().min(1).max(500).default(50),
         offset: z.number().min(0).default(0),
       })
     )
     .query(async ({ ctx, input }) => {
       const conditions = [];
       if (input.tournamentId) conditions.push(eq(matches.tournamentId, input.tournamentId));
+      if (input.tournament) conditions.push(eq(matches.tournament, input.tournament));
       if (input.status) conditions.push(eq(matches.status, input.status));
 
       const rows = await ctx.db
@@ -711,37 +721,21 @@ const matchesRouter = router({
   updatePhase: adminProcedure
     .input(z.object({ matchId: z.string().uuid(), phase: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      // Get current phase before updating
-      const current = await ctx.db.query.matches.findFirst({
-        where: eq(matches.id, input.matchId),
-        columns: { matchPhase: true },
-      });
-      if (!current) throw new TRPCError({ code: "NOT_FOUND", message: "Match not found" });
-
-      const fromPhase = current.matchPhase ?? "idle";
-
-      // Update the phase
-      const [updated] = await ctx.db
-        .update(matches)
-        .set({ matchPhase: input.phase })
-        .where(eq(matches.id, input.matchId))
-        .returning();
-
-      if (!updated) throw new TRPCError({ code: "NOT_FOUND", message: "Match not found" });
-
-      // Fire lifecycle automation for phase transition
-      let lifecycle: { actions: string[] } = { actions: [] };
-      if (fromPhase !== input.phase) {
-        try {
-          lifecycle = await onPhaseTransition(ctx.db, input.matchId, fromPhase, input.phase);
-          log.info({ matchId: input.matchId, fromPhase, toPhase: input.phase, actions: lifecycle.actions }, "Phase transition automation executed");
-        } catch (err) {
-          log.error({ matchId: input.matchId, fromPhase, toPhase: input.phase, error: err instanceof Error ? err.message : String(err) }, "Phase transition automation failed");
-          // Don't throw — phase was already updated, automation failure is non-blocking
-        }
+      // Canonical helper: phase write + all side-effects in one call
+      const result = await applyMatchPhaseChange(
+        ctx.db,
+        input.matchId,
+        input.phase,
+        "admin:updatePhase"
+      );
+      if (!result) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Match not found" });
       }
 
-      return { ...updated, lifecycleActions: lifecycle.actions };
+      const updated = await ctx.db.query.matches.findFirst({
+        where: eq(matches.id, input.matchId),
+      });
+      return { ...updated, lifecycleActions: result.actions };
     }),
 
   refreshMatch: adminProcedure
@@ -798,21 +792,16 @@ const matchesRouter = router({
       if (match.matchPhase !== phase) changes.push(`phase: ${match.matchPhase} → ${phase}`);
       const nextRefresh = calculateNextRefreshAfter(phase, now);
 
+      // Data fields only — match_phase is NOT written here. It's updated
+      // by applyMatchPhaseChange below so all side-effects fire consistently
+      // (draft enablement, contest transitions, notifications, CM hooks).
       const updateSet: Record<string, any> = {
         status: newStatus,
-        matchPhase: phase,
         lastRefreshedAt: now,
         nextRefreshAfter: nextRefresh,
         lastFetchAction: "updated",
         lastFetchedAt: now,
       };
-
-      // Sync draftEnabled with phase transitions
-      if (phase === "pre_match") {
-        updateSet.draftEnabled = true;
-      } else if (phase === "live" || phase === "completed" || phase === "post_match") {
-        updateSet.draftEnabled = false;
-      }
 
       if (geminiUpdate?.result) updateSet.result = geminiUpdate.result;
       if (geminiUpdate?.scoreSummary) {
@@ -835,51 +824,20 @@ const matchesRouter = router({
         .where(eq(matches.id, input.matchId))
         .returning();
 
-      await invalidateHotCache("dashboard:");
-
-      // --- Auto-transition contests when match status changes ---
-      let contestsTransitioned = 0;
-
-      if (newStatus === "completed") {
-        // Match is completed → close any still-open or live contests
-        // "live" contests → "settling" (ready for settlement)
-        const settlingResult = await ctx.db
-          .update(contests)
-          .set({ status: "settling" })
-          .where(and(eq(contests.matchId, input.matchId), eq(contests.status, "live")))
-          .returning({ id: contests.id });
-
-        // "open" contests → "cancelled" (match ended before they went live)
-        const cancelledResult = await ctx.db
-          .update(contests)
-          .set({ status: "cancelled" })
-          .where(and(eq(contests.matchId, input.matchId), eq(contests.status, "open")))
-          .returning({ id: contests.id });
-
-        contestsTransitioned = settlingResult.length + cancelledResult.length;
-        if (settlingResult.length > 0) {
-          changes.push(`${settlingResult.length} contest(s) → settling`);
-        }
-        if (cancelledResult.length > 0) {
-          changes.push(`${cancelledResult.length} open contest(s) → cancelled`);
-        }
-        if (contestsTransitioned > 0) {
-          log.info({ matchId: input.matchId, settling: settlingResult.length, cancelled: cancelledResult.length }, "Contests transitioned on match completion");
-        }
-      } else if (newStatus === "live") {
-        // Match is live → lock any still-open contests
-        const lockedResult = await ctx.db
-          .update(contests)
-          .set({ status: "live" })
-          .where(and(eq(contests.matchId, input.matchId), eq(contests.status, "open")))
-          .returning({ id: contests.id });
-
-        contestsTransitioned = lockedResult.length;
-        if (lockedResult.length > 0) {
-          changes.push(`${lockedResult.length} contest(s) → live`);
-          log.info({ matchId: input.matchId, locked: lockedResult.length }, "Contests locked on match going live");
-        }
+      // Apply phase change via the canonical helper (no-op if unchanged).
+      // This fires draft enablement, contest transitions, user notifications,
+      // CM round hooks, prediction grace periods — everything.
+      const phaseResult = await applyMatchPhaseChange(
+        ctx.db,
+        input.matchId,
+        phase,
+        "admin:refreshMatch"
+      );
+      if (phaseResult && phaseResult.actions.length > 0) {
+        changes.push(...phaseResult.actions);
       }
+
+      await invalidateHotCache("dashboard:");
 
       log.info({ matchId: input.matchId, changes, geminiAvailable: !!geminiUpdate }, "Match status refreshed via Gemini");
 
@@ -888,7 +846,6 @@ const matchesRouter = router({
         status: newStatus,
         phase,
         changes,
-        contestsTransitioned,
         unchanged: changes.length === 0,
       };
     }),
@@ -1022,7 +979,9 @@ const matchesRouter = router({
         return total;
       };
 
-      // 1. Refresh match score — prefer direct scorecard fetch if we have externalId
+      // 1. Refresh match score — prefer direct scorecard fetch if we have externalId.
+      // Data fields only — match_phase is NOT written in either branch. It's
+      // applied at the end via applyMatchPhaseChange so side-effects fire.
       let newStatus = match.status;
       const cbIdMatch = match.externalId?.match(/cb-(?:match-)?(\d+)/);
       if (cbIdMatch) {
@@ -1045,12 +1004,10 @@ const matchesRouter = router({
           if (cbScore.tossWinner) { updateSet.tossWinner = cbScore.tossWinner; }
           if (cbScore.tossDecision) { updateSet.tossDecision = cbScore.tossDecision; }
 
-          // Sync matchPhase and draftEnabled with status
+          // Recompute and persist next-refresh schedule even though phase
+          // transition happens below.
           const phase = determineMatchPhase(match.startTime, null, newStatus);
-          if (match.matchPhase !== phase) { updateSet.matchPhase = phase; matchChanges.push(`phase: ${match.matchPhase} → ${phase}`); }
           updateSet.nextRefreshAfter = calculateNextRefreshAfter(phase, now);
-          if (phase === "pre_match") updateSet.draftEnabled = true;
-          else if (phase === "live" || phase === "completed" || phase === "post_match") updateSet.draftEnabled = false;
 
           await ctx.db.update(matches).set(updateSet).where(eq(matches.id, input.matchId));
         }
@@ -1079,31 +1036,28 @@ const matchesRouter = router({
           if (providerUpdate.tossWinner) { updateSet.tossWinner = providerUpdate.tossWinner; }
           if (providerUpdate.tossDecision) { updateSet.tossDecision = providerUpdate.tossDecision; }
 
-          // Sync matchPhase and draftEnabled with status
           const phase = determineMatchPhase(match.startTime, null, newStatus);
-          if (match.matchPhase !== phase) { updateSet.matchPhase = phase; matchChanges.push(`phase: ${match.matchPhase} → ${phase}`); }
           updateSet.nextRefreshAfter = calculateNextRefreshAfter(phase, now);
-          if (phase === "pre_match") updateSet.draftEnabled = true;
-          else if (phase === "live" || phase === "completed" || phase === "post_match") updateSet.draftEnabled = false;
 
           await ctx.db.update(matches).set(updateSet).where(eq(matches.id, input.matchId));
         }
       }
 
-      // 2. Auto-transition contests when match status changes
-      if (newStatus !== match.status) {
-        if (newStatus === "live") {
-          const locked = await ctx.db.update(contests).set({ status: "live" })
-            .where(and(eq(contests.matchId, input.matchId), eq(contests.status, "open"))).returning({ id: contests.id });
-          if (locked.length > 0) matchChanges.push(`${locked.length} contest(s) → live`);
-        } else if (newStatus === "completed") {
-          const settling = await ctx.db.update(contests).set({ status: "settling" })
-            .where(and(eq(contests.matchId, input.matchId), eq(contests.status, "live"))).returning({ id: contests.id });
-          const cancelled = await ctx.db.update(contests).set({ status: "cancelled" })
-            .where(and(eq(contests.matchId, input.matchId), eq(contests.status, "open"))).returning({ id: contests.id });
-          if (settling.length > 0) matchChanges.push(`${settling.length} contest(s) → settling`);
-          if (cancelled.length > 0) matchChanges.push(`${cancelled.length} open contest(s) → cancelled`);
-        }
+      // 2. Apply phase change via canonical helper — fires draft enablement,
+      // contest transitions, user notifications, CM hooks, prediction grace
+      // periods. This replaces the hand-rolled contest transition block.
+      const newPhase = determineMatchPhase(match.startTime, null, newStatus);
+      if (match.matchPhase !== newPhase) {
+        matchChanges.push(`phase: ${match.matchPhase} → ${newPhase}`);
+      }
+      const phaseResult = await applyMatchPhaseChange(
+        ctx.db,
+        input.matchId,
+        newPhase,
+        "admin:refreshScores"
+      );
+      if (phaseResult && phaseResult.actions.length > 0) {
+        matchChanges.push(...phaseResult.actions);
       }
 
       // 3. Fetch confirmed playing XI if toss has happened
@@ -2368,6 +2322,110 @@ const revenueRouter = router({
 });
 
 // ---------------------------------------------------------------------------
+// Admin Leagues — create and manage leagues on behalf of the platform
+// ---------------------------------------------------------------------------
+
+const leaguesRouter = router({
+  list: adminProcedure
+    .input(
+      z
+        .object({
+          format: z
+            .enum([
+              "salary_cap",
+              "draft",
+              "auction",
+              "prediction",
+              "cricket_manager",
+            ])
+            .optional(),
+          limit: z.number().min(1).max(100).default(50),
+          offset: z.number().min(0).default(0),
+        })
+        .optional()
+    )
+    .query(async ({ ctx, input }) => {
+      const conditions = [];
+      if (input?.format) conditions.push(eq(leagues.format, input.format));
+
+      const rows = await ctx.db
+        .select({
+          id: leagues.id,
+          name: leagues.name,
+          format: leagues.format,
+          tournament: leagues.tournament,
+          isPrivate: leagues.isPrivate,
+          maxMembers: leagues.maxMembers,
+          status: leagues.status,
+          ownerId: leagues.ownerId,
+          createdAt: leagues.createdAt,
+        })
+        .from(leagues)
+        .where(conditions.length > 0 ? and(...conditions) : undefined)
+        .orderBy(desc(leagues.createdAt))
+        .limit(input?.limit ?? 50)
+        .offset(input?.offset ?? 0);
+
+      return rows;
+    }),
+
+  create: adminProcedure
+    .input(createLeagueSchema.extend({ isPrivate: z.boolean().default(false) }))
+    .mutation(async ({ ctx, input }) => {
+      const inviteCode = randomBytes(6).toString("hex");
+
+      const [league] = await ctx.db
+        .insert(leagues)
+        .values({
+          name: input.name,
+          ownerId: ctx.user.id,
+          format: input.format,
+          sport: input.sport,
+          tournament: input.tournament,
+          season: input.season,
+          isPrivate: input.isPrivate,
+          inviteCode,
+          maxMembers: input.maxMembers,
+          template: input.template,
+          rules: (input.rules ?? {}) as Record<string, unknown>,
+        })
+        .returning();
+
+      await ctx.db.insert(leagueMembers).values({
+        leagueId: league!.id,
+        userId: ctx.user.id,
+        role: "owner",
+      });
+
+      log.info({ leagueId: league!.id, format: input.format }, "Admin league created");
+      return league;
+    }),
+
+  get: adminProcedure
+    .input(z.object({ leagueId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      const league = await ctx.db.query.leagues.findFirst({
+        where: eq(leagues.id, input.leagueId),
+      });
+      if (!league) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "League not found" });
+      }
+      const members = await ctx.db
+        .select()
+        .from(leagueMembers)
+        .where(eq(leagueMembers.leagueId, input.leagueId));
+      return { ...league, members };
+    }),
+
+  delete: adminProcedure
+    .input(z.object({ leagueId: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      await ctx.db.delete(leagues).where(eq(leagues.id, input.leagueId));
+      return { deleted: true };
+    }),
+});
+
+// ---------------------------------------------------------------------------
 // Merged admin router
 // ---------------------------------------------------------------------------
 
@@ -2376,6 +2434,7 @@ export const adminRouter = router({
   matches: matchesRouter,
   players: playersRouter,
   contests: contestsRouter,
+  leagues: leaguesRouter,
   config: configRouter,
   leagueConfig: leagueConfigRouter,
   users: usersRouter,

--- a/packages/api/src/routers/cricket-manager.ts
+++ b/packages/api/src/routers/cricket-manager.ts
@@ -1,0 +1,525 @@
+/**
+ * Cricket Manager — tRPC router
+ *
+ * CM is layered on the leagues table. League CRUD/join flows live in the
+ * league router; this router handles CM-specific round composition, entries,
+ * leaderboards, and lifecycle.
+ */
+
+import { z } from "zod";
+import {
+  router,
+  protectedProcedure,
+  adminProcedure,
+  proProcedure,
+} from "../trpc";
+import { TRPCError } from "@trpc/server";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import {
+  leagues,
+  leagueMembers,
+  cmRounds,
+  cmContests,
+  cmContestMembers,
+  cmEntries,
+  cmLeagueStandings,
+  matches,
+  users,
+} from "@draftplay/db";
+import {
+  composeRound,
+  updateRound,
+  deleteRound,
+  submitEntry,
+  settleRound,
+  populateRoundPlayerPool,
+  tickRoundLifecycles,
+  joinCmLeague,
+  type EligiblePlayer,
+} from "../services/cm-service";
+import {
+  rateMyXi,
+  suggestBattingOrder,
+  suggestBowlingOrder,
+  whatIf,
+  type PlayerProjection,
+} from "../services/cm-guru";
+
+// ─── Input schemas ──────────────────────────────────────────────────────
+
+const playerSlotSchema = z.object({ playerId: z.string().uuid() });
+const battingSlotSchema = z.object({
+  position: z.number().int().min(1).max(11),
+  playerId: z.string().uuid(),
+});
+const bowlingSlotSchema = z.object({
+  priority: z.number().int().min(1),
+  playerId: z.string().uuid(),
+});
+
+// ─── Router ─────────────────────────────────────────────────────────────
+
+export const cricketManagerRouter = router({
+  // ── League-scoped queries ─────────────────────────────────────────────
+
+  /** Join a CM league — charges the league entry fee from rules.cricketManager.entryFee */
+  joinLeague: protectedProcedure
+    .input(z.object({ leagueId: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      return joinCmLeague(ctx.db, ctx.user.id, input.leagueId);
+    }),
+
+  /** Get all CM rounds for a league. */
+  getLeagueRounds: protectedProcedure
+    .input(z.object({ leagueId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      const league = await ctx.db.query.leagues.findFirst({
+        where: eq(leagues.id, input.leagueId),
+      });
+      if (!league) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "League not found",
+        });
+      }
+      if (league.format !== "cricket_manager") {
+        return [];
+      }
+
+      return ctx.db
+        .select()
+        .from(cmRounds)
+        .where(eq(cmRounds.leagueId, input.leagueId))
+        .orderBy(cmRounds.roundNumber);
+    }),
+
+  /** Round detail with attached match list and current user's entry. */
+  getRound: protectedProcedure
+    .input(z.object({ roundId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      const round = await ctx.db.query.cmRounds.findFirst({
+        where: eq(cmRounds.id, input.roundId),
+      });
+      if (!round) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Round not found" });
+      }
+
+      const matchRows =
+        round.matchIds.length > 0
+          ? await ctx.db
+              .select()
+              .from(matches)
+              .where(inArray(matches.id, round.matchIds))
+          : [];
+
+      const entry = await ctx.db.query.cmEntries.findFirst({
+        where: and(
+          eq(cmEntries.roundId, input.roundId),
+          eq(cmEntries.userId, ctx.user.id)
+        ),
+      });
+
+      return {
+        ...round,
+        matches: matchRows,
+        myEntry: entry ?? null,
+      };
+    }),
+
+  // ── Entries ──────────────────────────────────────────────────────────
+
+  submitEntry: protectedProcedure
+    .input(
+      z.object({
+        roundId: z.string().uuid(),
+        players: z.array(playerSlotSchema).length(11),
+        battingOrder: z.array(battingSlotSchema).length(11),
+        bowlingPriority: z.array(bowlingSlotSchema).min(5),
+        toss: z.enum(["bat_first", "bowl_first"]),
+        chipUsed: z.string().optional(),
+        chipTarget: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      return submitEntry(ctx.db, ctx.user.id, input);
+    }),
+
+  getMyEntry: protectedProcedure
+    .input(z.object({ roundId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      return ctx.db.query.cmEntries.findFirst({
+        where: and(
+          eq(cmEntries.roundId, input.roundId),
+          eq(cmEntries.userId, ctx.user.id)
+        ),
+      });
+    }),
+
+  /**
+   * Get an entry with its per-player breakdown hydrated.
+   * Used by:
+   *  - round hub live scorecard (user looks at their own entry)
+   *  - post-settlement reveal (user looks at a winner's entry)
+   * Visibility rule: other users' entries are only visible after settlement.
+   */
+  getEntryDetail: protectedProcedure
+    .input(
+      z.object({
+        roundId: z.string().uuid(),
+        userId: z.string().uuid().optional(),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      const targetUserId = input.userId ?? ctx.user.id;
+      const entry = await ctx.db.query.cmEntries.findFirst({
+        where: and(
+          eq(cmEntries.roundId, input.roundId),
+          eq(cmEntries.userId, targetUserId)
+        ),
+      });
+      if (!entry) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Entry not found" });
+      }
+
+      // Visibility: can always see own entry; others only after settlement
+      if (targetUserId !== ctx.user.id) {
+        const round = await ctx.db.query.cmRounds.findFirst({
+          where: eq(cmRounds.id, input.roundId),
+        });
+        if (round?.status !== "settled") {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "Other entries are hidden until the round settles",
+          });
+        }
+      }
+
+      return entry;
+    }),
+
+  // ── Leaderboards ─────────────────────────────────────────────────────
+
+  getRoundLeaderboard: protectedProcedure
+    .input(
+      z.object({
+        roundId: z.string().uuid(),
+        limit: z.number().int().min(1).max(200).default(50),
+        offset: z.number().int().min(0).default(0),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      const contest = await ctx.db.query.cmContests.findFirst({
+        where: and(
+          eq(cmContests.roundId, input.roundId),
+          eq(cmContests.contestType, "mega")
+        ),
+      });
+      if (!contest) return { rows: [] };
+
+      const rows = await ctx.db
+        .select({
+          userId: cmContestMembers.userId,
+          rank: cmContestMembers.rank,
+          prizeWon: cmContestMembers.prizeWon,
+          nrr: cmEntries.nrr,
+          battingTotal: cmEntries.battingTotal,
+          bowlingTotal: cmEntries.bowlingTotal,
+          battingWickets: cmEntries.battingWickets,
+          bowlingWickets: cmEntries.bowlingWickets,
+          email: users.email,
+        })
+        .from(cmContestMembers)
+        .innerJoin(cmEntries, eq(cmContestMembers.entryId, cmEntries.id))
+        .innerJoin(users, eq(cmContestMembers.userId, users.id))
+        .where(eq(cmContestMembers.contestId, contest.id))
+        .orderBy(
+          sql`${cmContestMembers.rank} NULLS LAST`,
+          desc(cmEntries.nrr)
+        )
+        .limit(input.limit)
+        .offset(input.offset);
+
+      return { rows, contestId: contest.id };
+    }),
+
+  getLeagueStandings: protectedProcedure
+    .input(
+      z.object({
+        leagueId: z.string().uuid(),
+        limit: z.number().int().min(1).max(200).default(50),
+        offset: z.number().int().min(0).default(0),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      return ctx.db
+        .select({
+          userId: cmLeagueStandings.userId,
+          rank: cmLeagueStandings.currentRank,
+          totalNrr: cmLeagueStandings.totalNrr,
+          roundsPlayed: cmLeagueStandings.roundsPlayed,
+          wins: cmLeagueStandings.wins,
+          losses: cmLeagueStandings.losses,
+          bestNrr: cmLeagueStandings.bestNrr,
+          worstNrr: cmLeagueStandings.worstNrr,
+          avgNrr: cmLeagueStandings.avgNrr,
+          currentWinStreak: cmLeagueStandings.currentWinStreak,
+          bestWinStreak: cmLeagueStandings.bestWinStreak,
+          prizeWon: cmLeagueStandings.prizeWon,
+          email: users.email,
+        })
+        .from(cmLeagueStandings)
+        .innerJoin(users, eq(cmLeagueStandings.userId, users.id))
+        .where(eq(cmLeagueStandings.leagueId, input.leagueId))
+        .orderBy(
+          sql`${cmLeagueStandings.currentRank} NULLS LAST`,
+          desc(cmLeagueStandings.totalNrr)
+        )
+        .limit(input.limit)
+        .offset(input.offset);
+    }),
+
+  // ── Guru AI (pro-gated) ──────────────────────────────────────────────
+
+  /** Rate the user's current entry on the given round. */
+  rateMyXi: proProcedure
+    .input(z.object({ roundId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      const round = await ctx.db.query.cmRounds.findFirst({
+        where: eq(cmRounds.id, input.roundId),
+      });
+      if (!round) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Round not found" });
+      }
+      const entry = await ctx.db.query.cmEntries.findFirst({
+        where: and(
+          eq(cmEntries.roundId, input.roundId),
+          eq(cmEntries.userId, ctx.user.id)
+        ),
+      });
+      if (!entry) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Build your entry first",
+        });
+      }
+
+      const pool = (round.eligiblePlayers ?? []) as EligiblePlayer[];
+      const byId = new Map(pool.map((p) => [p.playerId, p]));
+      const squadIds = (entry.players as Array<{ playerId: string }>).map(
+        (p) => p.playerId
+      );
+      const squad = squadIds
+        .map((id) => byId.get(id))
+        .filter((p): p is EligiblePlayer => !!p);
+
+      // Projections — best effort. Use the round's first match as context.
+      const proj: PlayerProjection[] = [];
+      // For the Guru analysis we read whatever's been stored in eligiblePlayers' `projectedPoints`
+      // plus any cached projection via the existing analytics endpoint fallback is skipped
+      // to keep the call synchronous. Rate is rule-based; projections are optional.
+      return rateMyXi({
+        squad,
+        projections: proj,
+        battingOrder: (entry.battingOrder as Array<{
+          position: number;
+          playerId: string;
+        }>)
+          .sort((a, b) => a.position - b.position)
+          .map((b) => b.playerId),
+        bowlingPriority: (entry.bowlingPriority as Array<{
+          priority: number;
+          playerId: string;
+        }>)
+          .sort((a, b) => a.priority - b.priority)
+          .map((b) => b.playerId),
+      });
+    }),
+
+  /** AI suggestion for optimal batting order given current squad + recent stats. */
+  suggestBattingOrder: proProcedure
+    .input(z.object({ roundId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      const round = await ctx.db.query.cmRounds.findFirst({
+        where: eq(cmRounds.id, input.roundId),
+      });
+      if (!round) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Round not found" });
+      }
+      const entry = await ctx.db.query.cmEntries.findFirst({
+        where: and(
+          eq(cmEntries.roundId, input.roundId),
+          eq(cmEntries.userId, ctx.user.id)
+        ),
+      });
+      if (!entry) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Build your entry first",
+        });
+      }
+
+      const pool = (round.eligiblePlayers ?? []) as EligiblePlayer[];
+      const byId = new Map(pool.map((p) => [p.playerId, p]));
+      const squadIds = (entry.players as Array<{ playerId: string }>).map(
+        (p) => p.playerId
+      );
+      const squad = squadIds
+        .map((id) => byId.get(id))
+        .filter((p): p is EligiblePlayer => !!p);
+
+      return suggestBattingOrder(squad, []);
+    }),
+
+  /** AI suggestion for optimal bowling priority. */
+  suggestBowlingOrder: proProcedure
+    .input(z.object({ roundId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      const round = await ctx.db.query.cmRounds.findFirst({
+        where: eq(cmRounds.id, input.roundId),
+      });
+      if (!round) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Round not found" });
+      }
+      const entry = await ctx.db.query.cmEntries.findFirst({
+        where: and(
+          eq(cmEntries.roundId, input.roundId),
+          eq(cmEntries.userId, ctx.user.id)
+        ),
+      });
+      if (!entry) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Build your entry first",
+        });
+      }
+
+      const pool = (round.eligiblePlayers ?? []) as EligiblePlayer[];
+      const byId = new Map(pool.map((p) => [p.playerId, p]));
+      const squadIds = (entry.players as Array<{ playerId: string }>).map(
+        (p) => p.playerId
+      );
+      const squad = squadIds
+        .map((id) => byId.get(id))
+        .filter((p): p is EligiblePlayer => !!p);
+
+      return suggestBowlingOrder(squad, []);
+    }),
+
+  /**
+   * Post-settlement "What If" — compare the user's chosen order with the
+   * AI-suggested order and show the delta. Pro-gated.
+   */
+  whatIf: proProcedure
+    .input(z.object({ roundId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      const round = await ctx.db.query.cmRounds.findFirst({
+        where: eq(cmRounds.id, input.roundId),
+      });
+      if (!round) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Round not found" });
+      }
+      const entry = await ctx.db.query.cmEntries.findFirst({
+        where: and(
+          eq(cmEntries.roundId, input.roundId),
+          eq(cmEntries.userId, ctx.user.id)
+        ),
+      });
+      if (!entry) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "No entry found" });
+      }
+
+      const pool = (round.eligiblePlayers ?? []) as EligiblePlayer[];
+      const byId = new Map(pool.map((p) => [p.playerId, p]));
+      const squadIds = (entry.players as Array<{ playerId: string }>).map(
+        (p) => p.playerId
+      );
+      const squad = squadIds
+        .map((id) => byId.get(id))
+        .filter((p): p is EligiblePlayer => !!p);
+
+      const actualBattingOrder = (
+        entry.battingOrder as Array<{ position: number; playerId: string }>
+      )
+        .sort((a, b) => a.position - b.position)
+        .map((b) => b.playerId);
+      const actualBowlingPriority = (
+        entry.bowlingPriority as Array<{ priority: number; playerId: string }>
+      )
+        .sort((a, b) => a.priority - b.priority)
+        .map((b) => b.playerId);
+
+      const suggestedBat = suggestBattingOrder(squad, []).map(
+        (s) => s.playerId
+      );
+      const suggestedBowl = suggestBowlingOrder(squad, []).map(
+        (s) => s.playerId
+      );
+
+      return whatIf({
+        actualBattingOrder,
+        actualBowlingPriority,
+        suggestedBattingOrder: suggestedBat,
+        suggestedBowlingPriority: suggestedBowl,
+        projectionsByPlayerId: new Map(),
+      });
+    }),
+
+  // ── Admin: round composition ─────────────────────────────────────────
+
+  composeRound: adminProcedure
+    .input(
+      z.object({
+        leagueId: z.string().uuid(),
+        roundNumber: z.number().int().positive(),
+        name: z.string().min(1).max(200),
+        matchIds: z.array(z.string().uuid()).min(1).max(50),
+        lockTime: z.coerce.date().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      return composeRound(ctx.db, input);
+    }),
+
+  updateRound: adminProcedure
+    .input(
+      z.object({
+        roundId: z.string().uuid(),
+        name: z.string().min(1).max(200).optional(),
+        matchIds: z.array(z.string().uuid()).min(1).max(50).optional(),
+        lockTime: z.coerce.date().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      await updateRound(ctx.db, input);
+      return { updated: true };
+    }),
+
+  deleteRound: adminProcedure
+    .input(z.object({ roundId: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      await deleteRound(ctx.db, input.roundId);
+      return { deleted: true };
+    }),
+
+  populateRoundPlayers: adminProcedure
+    .input(z.object({ roundId: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      const pool: EligiblePlayer[] = await populateRoundPlayerPool(
+        ctx.db,
+        input.roundId
+      );
+      return { count: pool.length };
+    }),
+
+  settleRound: adminProcedure
+    .input(z.object({ roundId: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      await settleRound(ctx.db, input.roundId);
+      return { settled: true };
+    }),
+
+  tickLifecycles: adminProcedure.mutation(async ({ ctx }) => {
+    await tickRoundLifecycles(ctx.db);
+    return { ok: true };
+  }),
+});

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -20,6 +20,7 @@ import { adminRouter } from "./admin";
 import { subscriptionRouter } from "./subscription";
 import { chatRouter } from "./chat";
 import { auctionAiRouter } from "./auction-ai";
+import { cricketManagerRouter } from "./cricket-manager";
 import { seedCricketData } from "../services/cricket-data";
 
 export const appRouter = router({
@@ -44,6 +45,7 @@ export const appRouter = router({
   subscription: subscriptionRouter,
   chat: chatRouter,
   auctionAi: auctionAiRouter,
+  cricketManager: cricketManagerRouter,
 
   seed: publicProcedure.mutation(async ({ ctx }) => {
     return seedCricketData(ctx.db);

--- a/packages/api/src/routers/league.ts
+++ b/packages/api/src/routers/league.ts
@@ -395,18 +395,20 @@ export const leagueRouter = router({
   create: protectedProcedure
     .input(createLeagueSchema)
     .mutation(async ({ ctx, input }) => {
-      // Check league count limit based on user's tier
-      const tier = await getUserTier(ctx.db, ctx.user.id);
-      const tierConfig = DEFAULT_TIER_CONFIGS[tier];
-      const [ownedCount] = await ctx.db
-        .select({ count: count() })
-        .from(leagues)
-        .where(eq(leagues.ownerId, ctx.user.id));
-      if (ownedCount && ownedCount.count >= tierConfig.features.maxLeagues) {
-        throw new TRPCError({
-          code: "FORBIDDEN",
-          message: `You've reached the ${tierConfig.features.maxLeagues} league limit for ${tierConfig.name} tier. Upgrade to create more leagues.`,
-        });
+      // Check league count limit based on user's tier (admins bypass the cap)
+      if (ctx.user.role !== "admin") {
+        const tier = await getUserTier(ctx.db, ctx.user.id);
+        const tierConfig = DEFAULT_TIER_CONFIGS[tier];
+        const [ownedCount] = await ctx.db
+          .select({ count: count() })
+          .from(leagues)
+          .where(eq(leagues.ownerId, ctx.user.id));
+        if (ownedCount && ownedCount.count >= tierConfig.features.maxLeagues) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: `You've reached the ${tierConfig.features.maxLeagues} league limit for ${tierConfig.name} tier. Upgrade to create more leagues.`,
+          });
+        }
       }
 
       const inviteCode = randomBytes(6).toString("hex");
@@ -443,7 +445,8 @@ export const leagueRouter = router({
         role: "owner",
       });
 
-      // Auto-create contests for all league formats immediately
+      // Auto-create contests for match-based league formats
+      // (cricket_manager rounds are composed manually by admin)
       if (input.format === "salary_cap" || input.format === "auction" || input.format === "draft") {
         try {
           const created = await autoCreateContestsForLeague(
@@ -535,6 +538,53 @@ export const leagueRouter = router({
       };
     }),
 
+  /** Join a public league by id (no invite code needed). */
+  joinPublic: protectedProcedure
+    .input(z.object({ leagueId: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      const league = await ctx.db.query.leagues.findFirst({
+        where: eq(leagues.id, input.leagueId),
+      });
+      if (!league) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "League not found" });
+      }
+      if (league.isPrivate) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "League is private — use invite code",
+        });
+      }
+
+      const memberCount = await ctx.db
+        .select({ count: count() })
+        .from(leagueMembers)
+        .where(eq(leagueMembers.leagueId, league.id));
+
+      if (memberCount[0] && memberCount[0].count >= league.maxMembers) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "League is full" });
+      }
+
+      const existing = await ctx.db.query.leagueMembers.findFirst({
+        where: and(
+          eq(leagueMembers.leagueId, league.id),
+          eq(leagueMembers.userId, ctx.user.id)
+        ),
+      });
+      if (existing) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "Already a member",
+        });
+      }
+
+      await ctx.db.insert(leagueMembers).values({
+        leagueId: league.id,
+        userId: ctx.user.id,
+        role: "member",
+      });
+      return league;
+    }),
+
   join: protectedProcedure
     .input(z.object({ inviteCode: z.string() }))
     .mutation(async ({ ctx, input }) => {
@@ -582,6 +632,52 @@ export const leagueRouter = router({
     });
     return memberships;
   }),
+
+  /** Browse public leagues open to join (primarily admin-curated leagues) */
+  browsePublic: protectedProcedure
+    .input(
+      z
+        .object({
+          format: z
+            .enum([
+              "salary_cap",
+              "draft",
+              "auction",
+              "prediction",
+              "cricket_manager",
+            ])
+            .optional(),
+          limit: z.number().int().min(1).max(100).default(30),
+        })
+        .optional()
+    )
+    .query(async ({ ctx, input }) => {
+      const conditions = [eq(leagues.isPrivate, false), eq(leagues.status, "active")];
+      if (input?.format) conditions.push(eq(leagues.format, input.format));
+
+      const rows = await ctx.db
+        .select({
+          id: leagues.id,
+          name: leagues.name,
+          format: leagues.format,
+          tournament: leagues.tournament,
+          maxMembers: leagues.maxMembers,
+          rules: leagues.rules,
+          createdAt: leagues.createdAt,
+        })
+        .from(leagues)
+        .where(and(...conditions))
+        .orderBy(desc(leagues.createdAt))
+        .limit(input?.limit ?? 30);
+
+      // Exclude leagues the user has already joined
+      const myMemberships = await ctx.db
+        .select({ leagueId: leagueMembers.leagueId })
+        .from(leagueMembers)
+        .where(eq(leagueMembers.userId, ctx.user.id));
+      const joinedIds = new Set(myMemberships.map((m) => m.leagueId));
+      return rows.filter((l) => !joinedIds.has(l.id));
+    }),
 
   /** Get active auctions across all leagues the user is in */
   myActiveAuctions: protectedProcedure.query(async ({ ctx }) => {

--- a/packages/api/src/routers/match.ts
+++ b/packages/api/src/routers/match.ts
@@ -5,6 +5,7 @@ import { matches, contests, tournaments } from "@draftplay/db";
 import { getVisibleTournamentNames } from "../services/admin-config";
 import { getLogger } from "../lib/logger";
 import { determineMatchPhase, calculateNextRefreshAfter } from "@draftplay/shared";
+import { applyMatchPhaseChange } from "../services/match-lifecycle";
 
 const log = getLogger("match-router");
 
@@ -51,27 +52,24 @@ async function backgroundRefreshMatch(db: any, match: any) {
       if (cbScore.tossWinner) updateSet.tossWinner = cbScore.tossWinner;
       if (cbScore.tossDecision) updateSet.tossDecision = cbScore.tossDecision;
 
-      // Sync matchPhase + draftEnabled
+      // Compute the next-refresh schedule based on the incoming phase.
+      // match_phase itself is NOT written here — applyMatchPhaseChange below
+      // is the canonical path that fires all side-effects (draft, contests,
+      // notifications, CM hooks).
       const phase = determineMatchPhase(match.startTime, null, newStatus);
-      if (match.matchPhase !== phase) updateSet.matchPhase = phase;
       updateSet.nextRefreshAfter = calculateNextRefreshAfter(phase, now);
-      if (phase === "live") updateSet.draftEnabled = false;
-      else if (phase === "completed" || phase === "post_match") updateSet.draftEnabled = false;
 
       await db.update(matches).set(updateSet).where(eq(matches.id, match.id));
 
-      // Auto-transition contests on status change
-      if (newStatus !== match.status) {
-        if (newStatus === "live") {
-          await db.update(contests).set({ status: "live" })
-            .where(and(eq(contests.matchId, match.id), eq(contests.status, "open")));
-        } else if (newStatus === "completed") {
-          await db.update(contests).set({ status: "settling" })
-            .where(and(eq(contests.matchId, match.id), eq(contests.status, "live")));
-          await db.update(contests).set({ status: "cancelled" })
-            .where(and(eq(contests.matchId, match.id), eq(contests.status, "open")));
-        }
-      }
+      // Apply phase change canonically (no-op if unchanged). Side-effects:
+      // draft enablement/disablement, contest status transitions, user
+      // notifications, CM round hooks, prediction grace periods.
+      await applyMatchPhaseChange(
+        db,
+        match.id,
+        phase,
+        "background:liveMatchRefresh"
+      );
     }
 
     // 2. Fetch confirmed playing XI if toss just happened

--- a/packages/api/src/services/cm-engine.ts
+++ b/packages/api/src/services/cm-engine.ts
@@ -1,0 +1,489 @@
+/**
+ * Cricket Manager — 120-ball simulation engine
+ *
+ * Pure functions only. No DB, no I/O. Given a member's entry plus aggregated
+ * per-player stats for a round, produces batting/bowling totals and NRR.
+ *
+ * Spec: /docs/CRICKET_MANAGER_DRAFT.md §2, §7
+ */
+
+export type PlayerRole =
+  | "batsman"
+  | "bowler"
+  | "all_rounder"
+  | "wicket_keeper";
+
+export type TossChoice = "bat_first" | "bowl_first";
+
+/**
+ * Aggregated stats for a single player across all matches in a round window.
+ * Sum of runs, balls, overs, conceded across multiple real matches.
+ */
+export interface AggregatedPlayerStats {
+  playerId: string;
+  role: PlayerRole;
+  // Batting (sum across matches)
+  runs: number;
+  ballsFaced: number;
+  dismissed: boolean; // true if out in ANY of the matches played
+  matchesBatted: number;
+  // Bowling (sum across matches)
+  overs: number; // decimal overs (e.g., 8.0 = 8 overs, 4.3 = 4 overs 3 balls)
+  runsConceded: number;
+  wickets: number;
+  matchesBowled: number;
+}
+
+export interface EntryInput {
+  players: Array<{ playerId: string }>;
+  battingOrder: Array<{ position: number; playerId: string }>;
+  bowlingPriority: Array<{ priority: number; playerId: string }>;
+}
+
+export interface RoundConfig {
+  ballLimit: number; // default 120
+  maxOversPerBowler: number; // default 4
+  /**
+   * Phantom-fill economy rate (runs per over). When `simulateBowling` is called
+   * with `applyPhantomFill = true` (i.e. `bat_first` toss) and the real bowling
+   * innings ends with unused balls remaining *and* fewer than 10 wickets, the
+   * unused balls are filled with notional runs at this ER. Closes the
+   * short-bowling asymmetry where the NRR denominator is fixed at 20 overs but
+   * the numerator gets to stay small. Usually set to the round's own average
+   * bowling ER, computed from real match data at settlement.
+   */
+  phantomFillER?: number;
+}
+
+export interface BattingSimResult {
+  total: number;
+  ballsUsed: number;
+  wickets: number;
+  allOut: boolean;
+  /** True when the batting innings stopped because the chase target was reached. */
+  chaseComplete: boolean;
+  details: Array<{
+    position: number;
+    playerId: string;
+    runs: number;
+    ballsFaced: number;
+    dismissed: boolean;
+    status: "full" | "partial" | "didnt_bat";
+  }>;
+}
+
+export interface BowlingSimResult {
+  total: number;
+  ballsBowled: number;
+  wickets: number;
+  /** True when the short-bowling gap was closed with phantom runs (bat_first only). */
+  phantomApplied: boolean;
+  /** Runs added by phantom fill (0 when phantomApplied is false). */
+  phantomRuns: number;
+  /** Balls added by phantom fill (0 when phantomApplied is false). */
+  phantomBalls: number;
+  details: Array<{
+    priority: number;
+    playerId: string;
+    cappedOvers: number;
+    ballsUsed: number;
+    runsConceded: number;
+    wickets: number;
+  }>;
+}
+
+export interface SimulationResult {
+  batting: BattingSimResult;
+  bowling: BowlingSimResult;
+  nrr: number; // 4 decimal places recommended
+  battingSr: number; // strike rate for tie-breaker
+  win: boolean; // batting > bowling
+}
+
+const OVERS_PER_INNINGS = 20;
+const BALLS_PER_OVER = 6;
+
+/**
+ * Convert a decimal-overs value (e.g., 4.3 = 4 overs 3 balls) to total balls.
+ * Note: cricket notation — 4.3 means 4 full overs + 3 balls = 27 balls, NOT 4.3 × 6 = 25.8.
+ */
+export function oversToBalls(overs: number): number {
+  const full = Math.floor(overs);
+  const partial = Math.round((overs - full) * 10); // 0-5
+  return full * BALLS_PER_OVER + partial;
+}
+
+export function ballsToOvers(balls: number): number {
+  const full = Math.floor(balls / BALLS_PER_OVER);
+  const partial = balls % BALLS_PER_OVER;
+  return full + partial / 10;
+}
+
+/**
+ * Run the batting simulation under the 120-ball limit.
+ * Processes batters in batting order; each contributes runs until their real
+ * balls faced are exhausted, the 120-ball budget is exhausted, or 10 wickets fall.
+ *
+ * When a chase `target` is provided (bowl-first scenario), the innings also
+ * stops the moment cumulative runs reach the target — the last batter's
+ * contribution is SR-scaled down to exactly hit the target. This is what makes
+ * bowl-first vs bat-first produce meaningfully different NRRs.
+ */
+export function simulateBatting(
+  entry: EntryInput,
+  statsByPlayerId: Map<string, AggregatedPlayerStats>,
+  config: RoundConfig,
+  target?: number
+): BattingSimResult {
+  const ballLimit = config.ballLimit;
+  const order = [...entry.battingOrder].sort((a, b) => a.position - b.position);
+  const hasTarget = target != null && target > 0;
+
+  let total = 0;
+  let ballsUsed = 0;
+  let wickets = 0;
+  let chaseComplete = false;
+  const details: BattingSimResult["details"] = [];
+
+  for (const slot of order) {
+    const stats = statsByPlayerId.get(slot.playerId);
+
+    if (!stats || (stats.ballsFaced === 0 && stats.runs === 0)) {
+      details.push({
+        position: slot.position,
+        playerId: slot.playerId,
+        runs: 0,
+        ballsFaced: 0,
+        dismissed: false,
+        status: "didnt_bat",
+      });
+      continue;
+    }
+
+    // Stop conditions: budget exhausted, all out, or chase already complete.
+    if (ballsUsed >= ballLimit || wickets >= 10 || chaseComplete) {
+      details.push({
+        position: slot.position,
+        playerId: slot.playerId,
+        runs: 0,
+        ballsFaced: 0,
+        dismissed: false,
+        status: "didnt_bat",
+      });
+      continue;
+    }
+
+    const remaining = ballLimit - ballsUsed;
+    let contribRuns = stats.runs;
+    let contribBalls = stats.ballsFaced;
+    let status: "full" | "partial" = "full";
+    let stoppedByChase = false;
+
+    // Ball-budget partial — SR-scale runs to fit the remaining balls
+    if (contribBalls > remaining) {
+      const sr = contribBalls > 0 ? contribRuns / contribBalls : 0;
+      contribBalls = remaining;
+      contribRuns = Math.round(sr * contribBalls);
+      status = "partial";
+    }
+
+    // Chase partial — if this batter's contribution would meet/exceed the
+    // target, SR-scale them down to land exactly at the target.
+    if (hasTarget && total + contribRuns >= target) {
+      const runsNeeded = target - total;
+      const sr = stats.ballsFaced > 0 ? stats.runs / stats.ballsFaced : 0;
+      const ballsNeeded = sr > 0 ? Math.ceil(runsNeeded / sr) : contribBalls;
+      contribRuns = runsNeeded;
+      contribBalls = Math.min(contribBalls, ballsNeeded);
+      status = "partial";
+      stoppedByChase = true;
+    }
+
+    total += contribRuns;
+    ballsUsed += contribBalls;
+
+    // Dismissal: only count the wicket if the batter used their full real innings.
+    // Chase-stopped batters are "not out" by definition.
+    const dismissedThisSlot =
+      stats.dismissed && status === "full" && !stoppedByChase;
+    if (dismissedThisSlot) wickets += 1;
+
+    details.push({
+      position: slot.position,
+      playerId: slot.playerId,
+      runs: contribRuns,
+      ballsFaced: contribBalls,
+      dismissed: dismissedThisSlot,
+      status,
+    });
+
+    if (stoppedByChase) chaseComplete = true;
+  }
+
+  return {
+    total,
+    ballsUsed,
+    wickets,
+    allOut: wickets >= 10,
+    chaseComplete,
+    details,
+  };
+}
+
+/**
+ * Run the bowling simulation. Bowlers bowl in priority order; each is capped at
+ * maxOversPerBowler (default 4). Conceded runs are scaled proportionally to the
+ * capped share of their real overs.
+ *
+ * "Lethality rule": if cumulative bowling wickets hit 10, bowling stops — the
+ * remaining balls in the 120-ball budget don't count against the bowling total.
+ * (§2.3 in the spec)
+ *
+ * Phantom-fill (opt-in via `applyPhantomFill`): when the real bowling innings
+ * ends *without* taking 10 wickets and with unused balls remaining, the gap is
+ * filled with notional runs at `config.phantomFillER` runs per over. This
+ * closes the short-bowling asymmetry — a user can no longer harvest NRR by
+ * stacking ghost bowlers whose 0-over "spells" leave the denominator at 20 ov
+ * while contributing 0 real runs conceded. Only applied in `bat_first` toss;
+ * `bowl_first` uses actual-overs denominators and needs no phantom fill.
+ */
+export function simulateBowling(
+  entry: EntryInput,
+  statsByPlayerId: Map<string, AggregatedPlayerStats>,
+  config: RoundConfig,
+  applyPhantomFill: boolean = false
+): BowlingSimResult {
+  const ballLimit = config.ballLimit;
+  const maxBallsPerBowler = config.maxOversPerBowler * BALLS_PER_OVER;
+
+  const priority = [...entry.bowlingPriority].sort(
+    (a, b) => a.priority - b.priority
+  );
+
+  let total = 0;
+  let ballsBowled = 0;
+  let wickets = 0;
+  const details: BowlingSimResult["details"] = [];
+
+  for (const slot of priority) {
+    const stats = statsByPlayerId.get(slot.playerId);
+    if (!stats) continue;
+
+    if (ballsBowled >= ballLimit || wickets >= 10) {
+      details.push({
+        priority: slot.priority,
+        playerId: slot.playerId,
+        cappedOvers: 0,
+        ballsUsed: 0,
+        runsConceded: 0,
+        wickets: 0,
+      });
+      continue;
+    }
+
+    const realBalls = oversToBalls(stats.overs);
+    if (realBalls === 0) continue;
+
+    const remainingBudget = ballLimit - ballsBowled;
+    const cappedBalls = Math.min(realBalls, maxBallsPerBowler, remainingBudget);
+
+    const share = cappedBalls / realBalls;
+    const conceded = Math.round(stats.runsConceded * share);
+    const wicketsTaken = Math.round(stats.wickets * share);
+
+    total += conceded;
+    ballsBowled += cappedBalls;
+    wickets = Math.min(10, wickets + wicketsTaken);
+
+    details.push({
+      priority: slot.priority,
+      playerId: slot.playerId,
+      cappedOvers: ballsToOvers(cappedBalls),
+      ballsUsed: cappedBalls,
+      runsConceded: conceded,
+      wickets: wicketsTaken,
+    });
+  }
+
+  // Phantom-fill: close the short-bowling gap with notional runs at the
+  // configured ER. Only applies when the innings didn't end by lethality
+  // (10 wickets) — a legitimate bowling-out should still be rewarded.
+  let phantomApplied = false;
+  let phantomRuns = 0;
+  let phantomBalls = 0;
+  if (
+    applyPhantomFill &&
+    ballsBowled < ballLimit &&
+    wickets < 10 &&
+    config.phantomFillER !== undefined &&
+    config.phantomFillER > 0
+  ) {
+    phantomBalls = ballLimit - ballsBowled;
+    const phantomOvers = phantomBalls / BALLS_PER_OVER;
+    phantomRuns = Math.round(phantomOvers * config.phantomFillER);
+    total += phantomRuns;
+    ballsBowled = ballLimit;
+    phantomApplied = true;
+  }
+
+  return {
+    total,
+    ballsBowled,
+    wickets,
+    phantomApplied,
+    phantomRuns,
+    phantomBalls,
+    details,
+  };
+}
+
+/**
+ * Compute NRR using ICC rules.
+ *
+ * By default both innings divide by the full 20-over allocation (bat_first
+ * mode). When `bowl_first` toss is used, the denominators become "actual
+ * overs" for whichever side used a rate-based boost:
+ *  - Batting: if the chase completed, actual batting overs; otherwise 20
+ *    (failed-chase penalty matching ICC's "all out = full allocation" rule).
+ *  - Bowling: always actual bowling overs in `bowl_first` (no phantom fill).
+ *
+ * Getting all out is naturally penalized via a lower run total, not a
+ * denominator change — the denominator defaults to 20 in bat_first.
+ */
+export function computeNrr(
+  battingTotal: number,
+  bowlingTotal: number,
+  battingOvers: number = OVERS_PER_INNINGS,
+  bowlingOvers: number = OVERS_PER_INNINGS
+): number {
+  const batRate = battingOvers > 0 ? battingTotal / battingOvers : 0;
+  const bowlRate = bowlingOvers > 0 ? bowlingTotal / bowlingOvers : 0;
+  return batRate - bowlRate;
+}
+
+/**
+ * Full simulation pipeline. Takes a member's entry and the aggregated player
+ * stats for the round, returns a settled result with NRR.
+ *
+ * Toss semantics (updated — see Appendix A in docs/CRICKET_MANAGER_DRAFT.md):
+ *
+ *  - **bat_first** (safe baseline): batters bat the full 120 balls (or until
+ *    10 wickets), bowlers bowl the full 120 balls. If real bowling ends early
+ *    without a bowling-out, phantom-fill closes the gap at the round's
+ *    average ER so ghost-bowler picks can't harvest NRR. Both denominators
+ *    stay at 20 overs.
+ *
+ *  - **bowl_first** (risk play): bowlers bowl first at their natural pace (no
+ *    phantom fill), then batters chase `bowlingTotal + 1`. The NRR denominators
+ *    become *actual overs* — fast chases get a real rate boost, short bowling
+ *    spells get a proportional punishment. A failed chase falls back to a
+ *    20-over batting denominator (ICC's all-out rule), so `bowl_first` is a
+ *    genuine risk/reward lever.
+ */
+export function simulateEntry(
+  entry: EntryInput,
+  statsByPlayerId: Map<string, AggregatedPlayerStats>,
+  config: RoundConfig = { ballLimit: 120, maxOversPerBowler: 4 },
+  toss: TossChoice = "bat_first"
+): SimulationResult {
+  let batting: BattingSimResult;
+  let bowling: BowlingSimResult;
+  let nrr: number;
+
+  if (toss === "bowl_first") {
+    // Risk play: real bowling innings (no phantom fill) then chase.
+    // Rate-based denominators reward fast chases and punish short bowling.
+    bowling = simulateBowling(entry, statsByPlayerId, config, false);
+    batting = simulateBatting(
+      entry,
+      statsByPlayerId,
+      config,
+      bowling.total + 1
+    );
+    const battingOvers = batting.chaseComplete
+      ? batting.ballsUsed / BALLS_PER_OVER
+      : OVERS_PER_INNINGS; // failed chase → ICC full-allocation penalty
+    const bowlingOvers =
+      bowling.ballsBowled > 0
+        ? bowling.ballsBowled / BALLS_PER_OVER
+        : OVERS_PER_INNINGS;
+    nrr = computeNrr(batting.total, bowling.total, battingOvers, bowlingOvers);
+  } else {
+    // Safe baseline: freeroll batting + phantom-filled bowling, 20 / 20
+    // denominators as originally specced.
+    bowling = simulateBowling(entry, statsByPlayerId, config, true);
+    batting = simulateBatting(entry, statsByPlayerId, config);
+    nrr = computeNrr(batting.total, bowling.total);
+  }
+
+  const battingSr =
+    batting.ballsUsed > 0 ? (batting.total / batting.ballsUsed) * 100 : 0;
+
+  return {
+    batting,
+    bowling,
+    nrr: Number(nrr.toFixed(4)),
+    battingSr: Number(battingSr.toFixed(4)),
+    win: batting.total > bowling.total,
+  };
+}
+
+/**
+ * Build aggregated stats from a flat list of per-player-per-match raw scores.
+ * Sums across multiple matches in the round window.
+ */
+export interface RawMatchScore {
+  playerId: string;
+  role: PlayerRole;
+  runs: number;
+  ballsFaced: number;
+  // Whether the player was dismissed in this specific match
+  isDismissed: boolean;
+  overs: number; // decimal overs
+  runsConceded: number;
+  wickets: number;
+}
+
+export function aggregatePlayerStats(
+  scores: RawMatchScore[]
+): Map<string, AggregatedPlayerStats> {
+  const byId = new Map<string, AggregatedPlayerStats>();
+
+  for (const s of scores) {
+    const existing = byId.get(s.playerId);
+    if (!existing) {
+      byId.set(s.playerId, {
+        playerId: s.playerId,
+        role: s.role,
+        runs: s.runs,
+        ballsFaced: s.ballsFaced,
+        dismissed: s.isDismissed,
+        matchesBatted: s.ballsFaced > 0 || s.runs > 0 ? 1 : 0,
+        overs: s.overs,
+        runsConceded: s.runsConceded,
+        wickets: s.wickets,
+        matchesBowled: s.overs > 0 ? 1 : 0,
+      });
+      continue;
+    }
+    existing.runs += s.runs;
+    existing.ballsFaced += s.ballsFaced;
+    existing.dismissed = existing.dismissed || s.isDismissed;
+    existing.matchesBatted += s.ballsFaced > 0 || s.runs > 0 ? 1 : 0;
+    existing.overs = addOvers(existing.overs, s.overs);
+    existing.runsConceded += s.runsConceded;
+    existing.wickets += s.wickets;
+    existing.matchesBowled += s.overs > 0 ? 1 : 0;
+  }
+
+  return byId;
+}
+
+/**
+ * Add two decimal-overs values respecting cricket notation (6 balls = 1 over).
+ * Example: 3.4 + 2.3 = 6.1 (not 5.7)
+ */
+export function addOvers(a: number, b: number): number {
+  const totalBalls = oversToBalls(a) + oversToBalls(b);
+  return ballsToOvers(totalBalls);
+}

--- a/packages/api/src/services/cm-guru.ts
+++ b/packages/api/src/services/cm-guru.ts
@@ -1,0 +1,363 @@
+/**
+ * Cricket Manager — Guru AI analysis
+ *
+ * Provides:
+ *  - rateMyXI: overall grade + strengths + weaknesses based on squad composition,
+ *    role distribution, projected points, and opponent matchups
+ *  - suggestBattingOrder: optimal order sorted by projected SR / projected points
+ *  - suggestBowlingOrder: optimal priority sorted by projected economy
+ *
+ * Currently rule-based for determinism and low latency. The structure is
+ * designed so a Gemini-backed commentary layer can be swapped in later.
+ */
+
+import type { EligiblePlayer } from "./cm-service";
+
+export interface PlayerProjection {
+  playerId: string;
+  projectedPoints: number;
+  captainRank?: number;
+}
+
+export interface RateMyXiInput {
+  squad: EligiblePlayer[];
+  projections: PlayerProjection[];
+  battingOrder: string[]; // playerIds in order
+  bowlingPriority: string[]; // playerIds in order
+}
+
+export interface RateMyXiResult {
+  grade: "A+" | "A" | "B" | "C" | "D";
+  score: number; // 0-100
+  headline: string;
+  strengths: string[];
+  weaknesses: string[];
+  suggestions: string[];
+  roleMix: {
+    batsmen: number;
+    bowlers: number;
+    allRounders: number;
+    wicketKeepers: number;
+  };
+  projectedTotal: number;
+}
+
+export interface OrderSuggestion {
+  playerId: string;
+  suggestedPosition: number; // 1-11 for batting, 1-N for bowling
+  reason: string;
+}
+
+// ─── Rate My XI ─────────────────────────────────────────────────────────
+
+export function rateMyXi(input: RateMyXiInput): RateMyXiResult {
+  const { squad, projections } = input;
+  const projMap = new Map(projections.map((p) => [p.playerId, p]));
+
+  // Role mix
+  const roleMix = {
+    batsmen: squad.filter((p) => p.role === "batsman").length,
+    bowlers: squad.filter((p) => p.role === "bowler").length,
+    allRounders: squad.filter((p) => p.role === "all_rounder").length,
+    wicketKeepers: squad.filter((p) => p.role === "wicket_keeper").length,
+  };
+
+  // Core metrics
+  const totalProj = squad.reduce(
+    (s, p) => s + (projMap.get(p.playerId)?.projectedPoints ?? 0),
+    0
+  );
+  const projCount = squad.filter((p) => projMap.has(p.playerId)).length;
+
+  const strengths: string[] = [];
+  const weaknesses: string[] = [];
+  const suggestions: string[] = [];
+
+  // Team diversity — spread across teams
+  const teamCounts: Record<string, number> = {};
+  for (const p of squad) {
+    teamCounts[p.team] = (teamCounts[p.team] ?? 0) + 1;
+  }
+  const maxTeamCount = Math.max(...Object.values(teamCounts));
+  const teamCount = Object.keys(teamCounts).length;
+
+  if (teamCount >= 6) {
+    strengths.push(
+      `Well diversified across ${teamCount} teams — resilient to any single team underperforming.`
+    );
+  } else if (teamCount <= 3) {
+    weaknesses.push(
+      `Only ${teamCount} teams represented. Heavy dependency — if one underperforms, your NRR suffers.`
+    );
+    suggestions.push("Add players from at least 2 more teams for better balance.");
+  }
+
+  if (maxTeamCount >= 8) {
+    weaknesses.push(
+      `${maxTeamCount} players from a single team — risky if they collapse.`
+    );
+  }
+
+  // Role balance
+  const bowlerPool = roleMix.bowlers + roleMix.allRounders;
+  if (bowlerPool >= 7) {
+    strengths.push(
+      `Deep bowling pool (${bowlerPool} bowlers + all-rounders) — can absorb wicket-less days.`
+    );
+  } else if (bowlerPool === 5) {
+    weaknesses.push(
+      "Bare minimum bowling — no backup if a bowler gets injured or drops a bad spell."
+    );
+  }
+
+  if (roleMix.allRounders >= 3) {
+    strengths.push(
+      `${roleMix.allRounders} all-rounders — flexible contribution on both sides.`
+    );
+  } else if (roleMix.allRounders === 0) {
+    weaknesses.push("No all-rounders — missing the dual-role multiplier.");
+    suggestions.push("Consider swapping a pure bat/bowl for a proven all-rounder.");
+  }
+
+  // Projections coverage — if we have data for 5+ players, use it
+  let projectedStrength = 50;
+  if (projCount >= 5) {
+    const avgProj = totalProj / projCount;
+    // Rough heuristic: T20 fantasy projections average ~30-40 pts.
+    projectedStrength = Math.min(100, Math.max(0, (avgProj - 15) * 2));
+
+    if (avgProj >= 40) {
+      strengths.push(
+        `Strong projected output (avg ${avgProj.toFixed(0)} pts/player).`
+      );
+    } else if (avgProj < 25) {
+      weaknesses.push(
+        `Low projected output (avg ${avgProj.toFixed(0)} pts/player) — consider higher-ceiling picks.`
+      );
+    }
+
+    // Top-heavy check
+    const topFour = squad
+      .map((p) => projMap.get(p.playerId)?.projectedPoints ?? 0)
+      .sort((a, b) => b - a)
+      .slice(0, 4);
+    const topSum = topFour.reduce((s, x) => s + x, 0);
+    if (topSum > totalProj * 0.65) {
+      weaknesses.push("Top-heavy squad — too dependent on your top 4 picks.");
+    }
+  }
+
+  // Score composition
+  let score = 60;
+  score += strengths.length * 6;
+  score -= weaknesses.length * 6;
+  score = Math.round(
+    score * 0.6 + projectedStrength * 0.4
+  );
+  score = Math.max(20, Math.min(100, score));
+
+  const grade: RateMyXiResult["grade"] =
+    score >= 90
+      ? "A+"
+      : score >= 78
+        ? "A"
+        : score >= 62
+          ? "B"
+          : score >= 45
+            ? "C"
+            : "D";
+
+  const headline =
+    grade === "A+"
+      ? "Elite squad — you've nailed the balance."
+      : grade === "A"
+        ? "Strong build with minor trade-offs."
+        : grade === "B"
+          ? "Solid core, room to optimize."
+          : grade === "C"
+            ? "Workable but has structural issues."
+            : "Needs rework — several risks.";
+
+  return {
+    grade,
+    score,
+    headline,
+    strengths: strengths.slice(0, 4),
+    weaknesses: weaknesses.slice(0, 4),
+    suggestions: suggestions.slice(0, 3),
+    roleMix,
+    projectedTotal: Math.round(totalProj),
+  };
+}
+
+// ─── Suggest Batting Order ──────────────────────────────────────────────
+
+/**
+ * Rule: openers with high strike rate first (maximize runs before 120 balls
+ * run out), all-rounders in middle, pure bowlers at the tail.
+ * Weight = recentSr × 0.6 + projectedPoints × 0.8 (fallback to 0 if missing)
+ */
+export function suggestBattingOrder(
+  squad: EligiblePlayer[],
+  projections: PlayerProjection[]
+): OrderSuggestion[] {
+  const projMap = new Map(projections.map((p) => [p.playerId, p]));
+
+  const scored = squad.map((p) => {
+    const proj = projMap.get(p.playerId);
+    const sr = p.recentSr ?? 0;
+    const pts = proj?.projectedPoints ?? 0;
+    // Bowlers get pushed to the bottom heavily
+    const roleBonus =
+      p.role === "batsman" || p.role === "wicket_keeper"
+        ? 200
+        : p.role === "all_rounder"
+          ? 100
+          : 0;
+    const weight = sr * 0.6 + pts * 0.8 + roleBonus;
+    return { player: p, weight };
+  });
+
+  scored.sort((a, b) => b.weight - a.weight);
+
+  return scored.map((s, i) => ({
+    playerId: s.player.playerId,
+    suggestedPosition: i + 1,
+    reason: battingReason(s.player, i + 1),
+  }));
+}
+
+function battingReason(p: EligiblePlayer, pos: number): string {
+  if (pos === 1 || pos === 2) {
+    return `${p.role === "wicket_keeper" ? "keeper-batter" : "opener"}${
+      p.recentSr ? ` with SR ${p.recentSr.toFixed(0)}` : ""
+    } — attack from ball one.`;
+  }
+  if (pos === 3 || pos === 4) {
+    return "anchor + aggressor role — middle overs builder.";
+  }
+  if (pos <= 7) {
+    return p.role === "all_rounder"
+      ? "finisher with late-order hitting."
+      : "middle-order consolidator.";
+  }
+  return "lower order — 120-ball budget may run out before you bat.";
+}
+
+// ─── Suggest Bowling Order ──────────────────────────────────────────────
+
+/**
+ * Rule: best economy first (lock down early), wicket-takers in the middle,
+ * and use the bowling-order cap of 4 overs per bowler intelligently.
+ * Weight = -recentEcon × 2 (lower = better) + projected points × 0.5
+ */
+export function suggestBowlingOrder(
+  squad: EligiblePlayer[],
+  projections: PlayerProjection[]
+): OrderSuggestion[] {
+  const projMap = new Map(projections.map((p) => [p.playerId, p]));
+
+  const canBowl = (role: string) =>
+    role === "bowler" || role === "all_rounder";
+  const bowlers = squad.filter((p) => canBowl(p.role));
+
+  const scored = bowlers.map((p) => {
+    const proj = projMap.get(p.playerId);
+    const econ = p.recentEcon ?? 10; // high default for unknown
+    const pts = proj?.projectedPoints ?? 0;
+    // Lower economy = higher weight. Pure bowlers get a boost.
+    const roleBonus = p.role === "bowler" ? 20 : 0;
+    const weight = -econ * 5 + pts * 0.5 + roleBonus;
+    return { player: p, weight };
+  });
+
+  scored.sort((a, b) => b.weight - a.weight);
+
+  return scored.map((s, i) => ({
+    playerId: s.player.playerId,
+    suggestedPosition: i + 1,
+    reason: bowlingReason(s.player, i + 1),
+  }));
+}
+
+function bowlingReason(p: EligiblePlayer, pos: number): string {
+  if (pos === 1) {
+    return `lead strike bowler${
+      p.recentEcon ? ` — ER ${p.recentEcon.toFixed(1)}` : ""
+    } — use full 4-over quota first.`;
+  }
+  if (pos === 2) {
+    return "second pick — get 4 overs in early while budget is fresh.";
+  }
+  if (pos === 3 || pos === 4) {
+    return "middle-overs specialist.";
+  }
+  return p.role === "all_rounder"
+    ? "death-overs option — saves your best for last."
+    : "backup — may not bowl if budget exhausted.";
+}
+
+// ─── What If analysis ──────────────────────────────────────────────────
+
+export interface WhatIfInput {
+  actualBattingOrder: string[];
+  actualBowlingPriority: string[];
+  suggestedBattingOrder: string[];
+  suggestedBowlingPriority: string[];
+  projectionsByPlayerId: Map<string, PlayerProjection>;
+}
+
+export interface WhatIfResult {
+  actualEstimate: number;
+  suggestedEstimate: number;
+  deltaPoints: number;
+  topDifferentialMoves: Array<{
+    playerId: string;
+    actualPos: number;
+    suggestedPos: number;
+    impact: number;
+  }>;
+}
+
+/**
+ * Quick delta estimate: sum projections of the first 7 in each order
+ * (because the 120-ball budget usually exhausts around there). This is
+ * a fast heuristic — the real engine runs on live data at settlement.
+ */
+export function whatIf(input: WhatIfInput): WhatIfResult {
+  const score = (order: string[]) => {
+    return order
+      .slice(0, 7)
+      .reduce(
+        (s, pid) =>
+          s + (input.projectionsByPlayerId.get(pid)?.projectedPoints ?? 0),
+        0
+      );
+  };
+
+  const actualEstimate = score(input.actualBattingOrder);
+  const suggestedEstimate = score(input.suggestedBattingOrder);
+
+  // Find biggest position changes
+  const actualPosMap = new Map(
+    input.actualBattingOrder.map((p, i) => [p, i + 1])
+  );
+  const suggestedPosMap = new Map(
+    input.suggestedBattingOrder.map((p, i) => [p, i + 1])
+  );
+  const moves = input.suggestedBattingOrder.map((pid) => {
+    const actualPos = actualPosMap.get(pid) ?? 99;
+    const suggestedPos = suggestedPosMap.get(pid) ?? 99;
+    const pts = input.projectionsByPlayerId.get(pid)?.projectedPoints ?? 0;
+    const impact = (actualPos - suggestedPos) * pts * 0.1;
+    return { playerId: pid, actualPos, suggestedPos, impact };
+  });
+  moves.sort((a, b) => Math.abs(b.impact) - Math.abs(a.impact));
+
+  return {
+    actualEstimate: Math.round(actualEstimate),
+    suggestedEstimate: Math.round(suggestedEstimate),
+    deltaPoints: Math.round(suggestedEstimate - actualEstimate),
+    topDifferentialMoves: moves.slice(0, 5),
+  };
+}

--- a/packages/api/src/services/cm-service.ts
+++ b/packages/api/src/services/cm-service.ts
@@ -1,0 +1,1747 @@
+/**
+ * Cricket Manager — business logic service layer
+ *
+ * Layered on top of the existing `leagues` / `leagueMembers` tables. A league
+ * with format='cricket_manager' gets CM rounds attached via `cm_rounds.leagueId`.
+ *
+ * Handles: round composition, lifecycle transitions, entry validation +
+ * submission, live updates, settlement, season standings.
+ *
+ * Spec: /docs/CRICKET_MANAGER_DRAFT.md
+ */
+
+import { and, eq, inArray, sql, desc } from "drizzle-orm";
+import {
+  leagues,
+  leagueMembers,
+  cmRounds,
+  cmContests,
+  cmEntries,
+  cmContestMembers,
+  cmLeagueStandings,
+  leagueAwards,
+  matches,
+  players,
+  playerMatchScores,
+  tournaments,
+} from "@draftplay/db";
+import type { Database } from "@draftplay/db";
+import type { LeagueRules } from "@draftplay/shared";
+import { TRPCError } from "@trpc/server";
+import { getLogger } from "../lib/logger";
+import { deductCoins, awardCoins } from "./pop-coins";
+import {
+  sendBatchNotifications,
+  NOTIFICATION_TYPES,
+} from "./notifications";
+import {
+  simulateEntry,
+  aggregatePlayerStats,
+  type AggregatedPlayerStats,
+  type PlayerRole,
+  type RawMatchScore,
+} from "./cm-engine";
+
+const log = getLogger("cm-service");
+
+// ─── Types ──────────────────────────────────────────────────────────────
+
+export interface EligiblePlayer {
+  playerId: string;
+  name: string;
+  team: string;
+  role: string;
+  photoUrl?: string | null;
+  nationality?: string | null;
+  battingStyle?: string;
+  bowlingStyle?: string;
+  recentSr?: number;
+  recentAvg?: number;
+  recentEcon?: number;
+  recentBowlSr?: number;
+  formNote?: string | null;
+  recentForm?: number | null;
+}
+
+export interface ComposeRoundInput {
+  leagueId: string;
+  roundNumber: number;
+  name: string;
+  matchIds: string[];
+  lockTime?: Date;
+}
+
+export interface UpdateRoundInput {
+  roundId: string;
+  name?: string;
+  matchIds?: string[];
+  lockTime?: Date;
+}
+
+// Default CM config used when a league's rules don't specify
+const DEFAULT_CM_CONFIG = {
+  ballLimit: 120,
+  minBowlers: 5,
+  maxOversPerBowler: 4,
+  prizeDistribution: [
+    { rank: 1, percent: 50 },
+    { rank: 2, percent: 30 },
+    { rank: 3, percent: 20 },
+  ],
+};
+
+function getCmConfig(league: typeof leagues.$inferSelect) {
+  const rules = (league.rules ?? {}) as LeagueRules;
+  const cm = rules.cricketManager ?? {};
+  return {
+    ballLimit: cm.ballLimit ?? DEFAULT_CM_CONFIG.ballLimit,
+    minBowlers: cm.minBowlersInSquad ?? DEFAULT_CM_CONFIG.minBowlers,
+    maxOversPerBowler:
+      cm.maxOversPerBowler ?? DEFAULT_CM_CONFIG.maxOversPerBowler,
+    prizeDistribution:
+      cm.prizeDistribution ?? DEFAULT_CM_CONFIG.prizeDistribution,
+    roundPrizeSplit: cm.roundPrizeSplit ?? {},
+    prizePool: cm.prizePool ?? 0,
+  };
+}
+
+// ─── Round composition ─────────────────────────────────────────────────
+
+export async function composeRound(db: Database, input: ComposeRoundInput) {
+  const league = await db.query.leagues.findFirst({
+    where: eq(leagues.id, input.leagueId),
+  });
+  if (!league) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "League not found" });
+  }
+  if (league.format !== "cricket_manager") {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "League is not a Cricket Manager league",
+    });
+  }
+
+  if (input.matchIds.length === 0) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "At least one match required",
+    });
+  }
+
+  const matchRows = await db
+    .select()
+    .from(matches)
+    .where(inArray(matches.id, input.matchIds));
+
+  if (matchRows.length !== input.matchIds.length) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "One or more match IDs are invalid",
+    });
+  }
+
+  // All matches must belong to the league's tournament AND be upcoming.
+  // Composing a round with live/completed matches is almost always an admin
+  // mistake — under the new lifecycle model the round would be unfair for
+  // users who can't react to info already revealed during those matches.
+  for (const m of matchRows) {
+    if (m.tournament !== league.tournament) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: `Match ${m.id} does not belong to the league's tournament`,
+      });
+    }
+    if (m.status === "live" || m.status === "completed") {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: `Match "${m.teamHome} vs ${m.teamAway}" is already ${m.status} — pick upcoming matches only`,
+      });
+    }
+  }
+
+  const windowStart = new Date(
+    Math.min(...matchRows.map((m) => m.startTime.getTime()))
+  );
+  const windowEnd = new Date(
+    Math.max(...matchRows.map((m) => m.startTime.getTime())) +
+      4 * 60 * 60 * 1000 // +4h cushion
+  );
+  // lockTime is display-only metadata now — entries lock when first match
+  // goes live, not at a wall-clock time. Store first match start for UI display.
+  const lockTime = input.lockTime ?? windowStart;
+
+  const cfg = getCmConfig(league);
+
+  // Resolve tournamentId if available (via tournament name match)
+  const tournamentRow = await db.query.tournaments.findFirst({
+    where: eq(tournaments.name, league.tournament),
+  });
+
+  const roundRows = await db
+    .insert(cmRounds)
+    .values({
+      leagueId: input.leagueId,
+      tournamentId: tournamentRow?.id,
+      roundNumber: input.roundNumber,
+      name: input.name,
+      matchIds: input.matchIds,
+      windowStart,
+      windowEnd,
+      lockTime,
+      ballLimit: cfg.ballLimit,
+      minBowlers: cfg.minBowlers,
+      maxOversPerBowler: cfg.maxOversPerBowler,
+      matchesTotal: input.matchIds.length,
+      // New rule: rounds are open from creation until first match goes live.
+      status: "open",
+    })
+    .returning();
+
+  const round = roundRows[0]!;
+
+  // Auto-populate the eligible player pool from the teams playing these matches.
+  // This runs again later (on pre_match phase transition) to catch playing-XI updates.
+  try {
+    await populateRoundPlayerPool(db, round.id);
+  } catch (err) {
+    log.warn(
+      { err, roundId: round.id },
+      "Initial player pool population failed — will retry on pre_match"
+    );
+  }
+
+  // Auto-create the default Mega contest for this round
+  const roundPrizePool =
+    cfg.roundPrizeSplit.perRoundPct != null
+      ? Math.round((cfg.prizePool * cfg.roundPrizeSplit.perRoundPct) / 100)
+      : 0;
+
+  await db.insert(cmContests).values({
+    roundId: round.id,
+    leagueId: league.id,
+    name: `${round.name} — Mega Contest`,
+    contestType: "mega",
+    entryFee: 0, // League entry fee covers round participation
+    prizePool: roundPrizePool,
+    prizeDistribution: cfg.prizeDistribution,
+    maxMembers: league.maxMembers,
+    status: "open",
+  });
+
+  log.info(
+    { roundId: round.id, leagueId: input.leagueId },
+    "CM round composed"
+  );
+  return round;
+}
+
+/**
+ * Check if any match in the round has gone live or completed. Once the
+ * round's first match kicks off, admin can no longer edit or delete it.
+ */
+async function anyMatchStarted(
+  db: Database,
+  matchIds: string[]
+): Promise<boolean> {
+  if (matchIds.length === 0) return false;
+  const rows = await db
+    .select({ status: matches.status })
+    .from(matches)
+    .where(inArray(matches.id, matchIds));
+  return rows.some(
+    (m) =>
+      m.status === "live" ||
+      m.status === "completed" ||
+      m.status === "abandoned"
+  );
+}
+
+export async function updateRound(db: Database, input: UpdateRoundInput) {
+  const round = await db.query.cmRounds.findFirst({
+    where: eq(cmRounds.id, input.roundId),
+  });
+  if (!round) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Round not found" });
+  }
+  // Allow edits as long as no match in the round has started.
+  if (round.status === "settled") {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Cannot edit a settled round",
+    });
+  }
+  if (await anyMatchStarted(db, round.matchIds)) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Cannot edit round — a match in this round has already started",
+    });
+  }
+
+  const updates: Partial<typeof cmRounds.$inferInsert> = {
+    updatedAt: new Date(),
+  };
+  if (input.name !== undefined) updates.name = input.name;
+  if (input.matchIds !== undefined) {
+    updates.matchIds = input.matchIds;
+    updates.matchesTotal = input.matchIds.length;
+    const matchRows = await db
+      .select()
+      .from(matches)
+      .where(inArray(matches.id, input.matchIds));
+    if (matchRows.length !== input.matchIds.length) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "Invalid match IDs",
+      });
+    }
+    // Re-validate: new match list can't contain anything already started.
+    for (const m of matchRows) {
+      if (m.status === "live" || m.status === "completed") {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `Match "${m.teamHome} vs ${m.teamAway}" is already ${m.status}`,
+        });
+      }
+    }
+    const newWindowStart = new Date(
+      Math.min(...matchRows.map((m) => m.startTime.getTime()))
+    );
+    updates.windowStart = newWindowStart;
+    updates.windowEnd = new Date(
+      Math.max(...matchRows.map((m) => m.startTime.getTime())) +
+        4 * 60 * 60 * 1000
+    );
+    // Keep lock_time in sync with the new first match
+    updates.lockTime = newWindowStart;
+  }
+  if (input.lockTime !== undefined) updates.lockTime = input.lockTime;
+
+  await db.update(cmRounds).set(updates).where(eq(cmRounds.id, input.roundId));
+}
+
+export async function deleteRound(db: Database, roundId: string) {
+  const round = await db.query.cmRounds.findFirst({
+    where: eq(cmRounds.id, roundId),
+  });
+  if (!round) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Round not found" });
+  }
+  if (round.status === "settled") {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Cannot delete a settled round",
+    });
+  }
+  if (await anyMatchStarted(db, round.matchIds)) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message:
+        "Cannot delete round — a match in this round has already started",
+    });
+  }
+  await db.delete(cmRounds).where(eq(cmRounds.id, roundId));
+}
+
+// ─── Player pool population ────────────────────────────────────────────
+
+/**
+ * Populate the eligible_players JSONB for a round. Called when round transitions
+ * upcoming → open. Uses all players on teams playing any of the round's matches.
+ */
+export async function populateRoundPlayerPool(
+  db: Database,
+  roundId: string
+): Promise<EligiblePlayer[]> {
+  const round = await db.query.cmRounds.findFirst({
+    where: eq(cmRounds.id, roundId),
+  });
+  if (!round)
+    throw new TRPCError({ code: "NOT_FOUND", message: "Round not found" });
+
+  const matchRows = await db
+    .select()
+    .from(matches)
+    .where(inArray(matches.id, round.matchIds));
+
+  const teamNames = new Set<string>();
+  for (const m of matchRows) {
+    teamNames.add(m.teamHome);
+    teamNames.add(m.teamAway);
+  }
+
+  const playerRows = await db
+    .select()
+    .from(players)
+    .where(inArray(players.team, Array.from(teamNames)));
+
+  const eligible: EligiblePlayer[] = playerRows.map((p) => {
+    const s = (p.stats as Record<string, unknown> | null) ?? {};
+    const num = (k: string): number | undefined => {
+      const v = s[k];
+      return typeof v === "number" ? v : undefined;
+    };
+    const str = (k: string): string | undefined => {
+      const v = s[k];
+      return typeof v === "string" ? v : undefined;
+    };
+    return {
+      playerId: p.id,
+      name: p.name,
+      team: p.team,
+      role: p.role,
+      photoUrl: p.photoUrl ?? null,
+      nationality: p.nationality ?? null,
+      battingStyle: p.battingStyle ?? undefined,
+      bowlingStyle: p.bowlingStyle ?? undefined,
+      recentSr: num("strikeRate"),
+      recentAvg: num("average") ?? num("battingAverage"),
+      recentEcon: num("economyRate"),
+      recentBowlSr: num("bowlingStrikeRate"),
+      formNote: str("formNote") ?? null,
+      recentForm: num("recentForm") ?? null,
+    };
+  });
+
+  await db
+    .update(cmRounds)
+    .set({ eligiblePlayers: eligible, updatedAt: new Date() })
+    .where(eq(cmRounds.id, roundId));
+
+  log.info({ roundId, count: eligible.length }, "Populated round player pool");
+  return eligible;
+}
+
+// ─── Entry validation + submission ─────────────────────────────────────
+
+export interface SubmitEntryInput {
+  roundId: string;
+  players: Array<{ playerId: string }>;
+  battingOrder: Array<{ position: number; playerId: string }>;
+  bowlingPriority: Array<{ priority: number; playerId: string }>;
+  toss: "bat_first" | "bowl_first";
+  chipUsed?: string;
+  chipTarget?: string;
+}
+
+export async function submitEntry(
+  db: Database,
+  userId: string,
+  input: SubmitEntryInput
+) {
+  const round = await db.query.cmRounds.findFirst({
+    where: eq(cmRounds.id, input.roundId),
+  });
+  if (!round)
+    throw new TRPCError({ code: "NOT_FOUND", message: "Round not found" });
+  // New rule: entry is accepted as long as the round is `open`. No wall-clock
+  // gate — the status is the single source of truth. Round flips to `live`
+  // the moment the first match goes live via onMatchPhaseTransition.
+  if (round.status !== "open") {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message:
+        round.status === "live"
+          ? "round is live — entries are locked"
+          : round.status === "settled"
+            ? "round is already settled"
+            : `round not accepting entries (status: ${round.status})`,
+    });
+  }
+
+  // Must be a league member
+  const membership = await db.query.leagueMembers.findFirst({
+    where: and(
+      eq(leagueMembers.leagueId, round.leagueId),
+      eq(leagueMembers.userId, userId)
+    ),
+  });
+  if (!membership) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Join the league first",
+    });
+  }
+
+  validateEntryShape(input, round);
+
+  // Upsert entry
+  const existing = await db.query.cmEntries.findFirst({
+    where: and(
+      eq(cmEntries.roundId, input.roundId),
+      eq(cmEntries.userId, userId)
+    ),
+  });
+
+  if (existing) {
+    await db
+      .update(cmEntries)
+      .set({
+        players: input.players,
+        battingOrder: input.battingOrder,
+        bowlingPriority: input.bowlingPriority,
+        toss: input.toss,
+        chipUsed: input.chipUsed,
+        chipTarget: input.chipTarget,
+        updatedAt: new Date(),
+      })
+      .where(eq(cmEntries.id, existing.id));
+    return existing;
+  }
+
+  const entryRows = await db
+    .insert(cmEntries)
+    .values({
+      roundId: input.roundId,
+      userId,
+      players: input.players,
+      battingOrder: input.battingOrder,
+      bowlingPriority: input.bowlingPriority,
+      toss: input.toss,
+      chipUsed: input.chipUsed,
+      chipTarget: input.chipTarget,
+    })
+    .returning();
+
+  const entry = entryRows[0]!;
+
+  // Auto-join the round's mega contest
+  const megaContest = await db.query.cmContests.findFirst({
+    where: and(
+      eq(cmContests.roundId, input.roundId),
+      eq(cmContests.contestType, "mega")
+    ),
+  });
+  if (megaContest) {
+    await db
+      .insert(cmContestMembers)
+      .values({
+        contestId: megaContest.id,
+        userId,
+        entryId: entry.id,
+      })
+      .onConflictDoNothing();
+    await db
+      .update(cmContests)
+      .set({
+        currentMembers: sql`${cmContests.currentMembers} + 1`,
+        updatedAt: new Date(),
+      })
+      .where(eq(cmContests.id, megaContest.id));
+  }
+
+  // Ensure user has a standings row
+  await db
+    .insert(cmLeagueStandings)
+    .values({ leagueId: round.leagueId, userId })
+    .onConflictDoNothing();
+
+  log.info(
+    { entryId: entry.id, userId, roundId: input.roundId },
+    "CM entry submitted"
+  );
+  return entry;
+}
+
+function validateEntryShape(
+  input: SubmitEntryInput,
+  round: typeof cmRounds.$inferSelect
+) {
+  if (input.players.length !== 11) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: `Must select exactly 11 players (got ${input.players.length})`,
+    });
+  }
+
+  const uniqueIds = new Set(input.players.map((p) => p.playerId));
+  if (uniqueIds.size !== 11) {
+    throw new TRPCError({ code: "BAD_REQUEST", message: "Duplicate players" });
+  }
+
+  const eligibleIds = new Set(
+    (round.eligiblePlayers as EligiblePlayer[]).map((p) => p.playerId)
+  );
+  if (eligibleIds.size > 0) {
+    for (const p of input.players) {
+      if (!eligibleIds.has(p.playerId)) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `Player ${p.playerId} is not eligible for this round`,
+        });
+      }
+    }
+  }
+
+  if (input.battingOrder.length !== 11) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Batting order must have 11 slots",
+    });
+  }
+  const positions = new Set(input.battingOrder.map((b) => b.position));
+  if (positions.size !== 11) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Batting order positions must be 1..11 and unique",
+    });
+  }
+  for (const b of input.battingOrder) {
+    if (b.position < 1 || b.position > 11) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "Invalid batting position",
+      });
+    }
+    if (!uniqueIds.has(b.playerId)) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "Batting order references player not in squad",
+      });
+    }
+  }
+
+  for (const b of input.bowlingPriority) {
+    if (!uniqueIds.has(b.playerId)) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "Bowling priority references player not in squad",
+      });
+    }
+  }
+
+  // Minimum bowler count (based on role from the round's player pool)
+  const poolByRole = new Map<string, string>();
+  for (const p of round.eligiblePlayers as EligiblePlayer[]) {
+    poolByRole.set(p.playerId, p.role);
+  }
+  if (poolByRole.size > 0) {
+    const bowlerCount = input.players.filter((p) => {
+      const r = poolByRole.get(p.playerId);
+      return r === "bowler" || r === "all_rounder";
+    }).length;
+    if (bowlerCount < round.minBowlers) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: `Need at least ${round.minBowlers} bowlers (got ${bowlerCount})`,
+      });
+    }
+  }
+}
+
+// ─── Simulation ────────────────────────────────────────────────────────
+
+export async function runEntrySimulation(
+  db: Database,
+  entryId: string
+): Promise<{ nrr: number; battingTotal: number; bowlingTotal: number }> {
+  const entry = await db.query.cmEntries.findFirst({
+    where: eq(cmEntries.id, entryId),
+  });
+  if (!entry)
+    throw new TRPCError({ code: "NOT_FOUND", message: "Entry not found" });
+
+  const round = await db.query.cmRounds.findFirst({
+    where: eq(cmRounds.id, entry.roundId),
+  });
+  if (!round)
+    throw new TRPCError({ code: "NOT_FOUND", message: "Round not found" });
+
+  const playerIds = (entry.players as Array<{ playerId: string }>).map(
+    (p) => p.playerId
+  );
+
+  const statsMap = await fetchAggregatedStats(db, round.matchIds, playerIds);
+  const phantomFillER = await computeRoundAvgER(db, round.matchIds);
+
+  const result = simulateEntry(
+    {
+      players: entry.players as Array<{ playerId: string }>,
+      battingOrder: entry.battingOrder as Array<{
+        position: number;
+        playerId: string;
+      }>,
+      bowlingPriority: entry.bowlingPriority as Array<{
+        priority: number;
+        playerId: string;
+      }>,
+    },
+    statsMap,
+    {
+      ballLimit: round.ballLimit,
+      maxOversPerBowler: round.maxOversPerBowler,
+      phantomFillER,
+    },
+    (entry.toss as "bat_first" | "bowl_first") ?? "bat_first"
+  );
+
+  await db
+    .update(cmEntries)
+    .set({
+      battingTotal: result.batting.total,
+      battingBallsUsed: result.batting.ballsUsed,
+      battingWickets: result.batting.wickets,
+      battingDetails: result.batting.details,
+      bowlingTotal: result.bowling.total,
+      bowlingBallsBowled: result.bowling.ballsBowled,
+      bowlingWickets: result.bowling.wickets,
+      bowlingDetails: result.bowling.details,
+      nrr: result.nrr.toString(),
+      battingSr: result.battingSr.toString(),
+      updatedAt: new Date(),
+    })
+    .where(eq(cmEntries.id, entryId));
+
+  return {
+    nrr: result.nrr,
+    battingTotal: result.batting.total,
+    bowlingTotal: result.bowling.total,
+  };
+}
+
+export async function fetchAggregatedStats(
+  db: Database,
+  matchIds: string[],
+  playerIds: string[]
+): Promise<Map<string, AggregatedPlayerStats>> {
+  if (playerIds.length === 0 || matchIds.length === 0) return new Map();
+
+  const scoreRows = await db
+    .select({
+      playerId: playerMatchScores.playerId,
+      runs: playerMatchScores.runs,
+      ballsFaced: playerMatchScores.ballsFaced,
+      overs: playerMatchScores.oversBowled,
+      runsConceded: playerMatchScores.runsConceded,
+      wickets: playerMatchScores.wickets,
+      isPlaying: playerMatchScores.isPlaying,
+      role: players.role,
+    })
+    .from(playerMatchScores)
+    .innerJoin(players, eq(playerMatchScores.playerId, players.id))
+    .where(
+      and(
+        inArray(playerMatchScores.matchId, matchIds),
+        inArray(playerMatchScores.playerId, playerIds)
+      )
+    );
+
+  const raw: RawMatchScore[] = scoreRows.map((r) => ({
+    playerId: r.playerId,
+    role: (r.role as PlayerRole) ?? "batsman",
+    runs: r.runs,
+    ballsFaced: r.ballsFaced,
+    isDismissed: r.ballsFaced > 0, // v1 heuristic — refine when dismissal flag available
+    overs: Number(r.overs ?? 0),
+    runsConceded: r.runsConceded,
+    wickets: r.wickets,
+  }));
+
+  return aggregatePlayerStats(raw);
+}
+
+// Fallback ER used when a round has no real bowling data yet (e.g. preview
+// before any match has started). A league-typical T20 ER for mid-innings.
+const FALLBACK_PHANTOM_ER = 8.5;
+
+/**
+ * Compute the round's own average bowling ER from every bowler in every match
+ * of the round. Used as the phantom-fill ER for `bat_first` simulations — the
+ * value self-calibrates to the round's conditions (batting paradises vs
+ * bowler-friendly pitches) rather than using a hardcoded constant.
+ */
+export async function computeRoundAvgER(
+  db: Database,
+  matchIds: string[]
+): Promise<number> {
+  if (matchIds.length === 0) return FALLBACK_PHANTOM_ER;
+  const rows = await db
+    .select({
+      overs: playerMatchScores.oversBowled,
+      runsConceded: playerMatchScores.runsConceded,
+    })
+    .from(playerMatchScores)
+    .where(inArray(playerMatchScores.matchId, matchIds));
+
+  let totalBalls = 0;
+  let totalRuns = 0;
+  for (const r of rows) {
+    const ov = Number(r.overs ?? 0);
+    if (ov <= 0) continue;
+    totalBalls += oversToBallsLocal(ov);
+    totalRuns += r.runsConceded ?? 0;
+  }
+  if (totalBalls === 0) return FALLBACK_PHANTOM_ER;
+  return (totalRuns / totalBalls) * 6;
+}
+
+// Local copy of the engine's cricket-notation overs→balls helper — avoids
+// importing it just for one call site.
+function oversToBallsLocal(overs: number): number {
+  const full = Math.floor(overs);
+  const partial = Math.round((overs - full) * 10);
+  return full * 6 + partial;
+}
+
+export async function rerankContest(db: Database, contestId: string) {
+  const members = await db
+    .select({
+      contestId: cmContestMembers.contestId,
+      userId: cmContestMembers.userId,
+      entryId: cmContestMembers.entryId,
+      nrr: cmEntries.nrr,
+      battingSr: cmEntries.battingSr,
+      bowlingWickets: cmEntries.bowlingWickets,
+      submittedAt: cmEntries.submittedAt,
+    })
+    .from(cmContestMembers)
+    .innerJoin(cmEntries, eq(cmContestMembers.entryId, cmEntries.id))
+    .where(eq(cmContestMembers.contestId, contestId));
+
+  members.sort((a, b) => {
+    const nrrA = Number(a.nrr);
+    const nrrB = Number(b.nrr);
+    if (nrrA !== nrrB) return nrrB - nrrA;
+    const srA = Number(a.battingSr);
+    const srB = Number(b.battingSr);
+    if (srA !== srB) return srB - srA;
+    if (a.bowlingWickets !== b.bowlingWickets)
+      return b.bowlingWickets - a.bowlingWickets;
+    return a.submittedAt.getTime() - b.submittedAt.getTime();
+  });
+
+  for (let i = 0; i < members.length; i++) {
+    const m = members[i]!;
+    await db
+      .update(cmContestMembers)
+      .set({ rank: i + 1 })
+      .where(
+        and(
+          eq(cmContestMembers.contestId, contestId),
+          eq(cmContestMembers.userId, m.userId)
+        )
+      );
+  }
+}
+
+/**
+ * Hook from score-updater: when a match updates, re-simulate all entries for
+ * every live CM round that includes this match.
+ */
+export async function onMatchScoreUpdate(db: Database, matchId: string) {
+  const liveRounds = await db
+    .select()
+    .from(cmRounds)
+    .where(
+      and(
+        eq(cmRounds.status, "live"),
+        sql`${cmRounds.matchIds} @> ${JSON.stringify([matchId])}::jsonb`
+      )
+    );
+
+  for (const round of liveRounds) {
+    const entries = await db
+      .select()
+      .from(cmEntries)
+      .where(eq(cmEntries.roundId, round.id));
+
+    for (const e of entries) {
+      try {
+        await runEntrySimulation(db, e.id);
+      } catch (err) {
+        log.error({ err, entryId: e.id }, "Failed to re-simulate entry");
+      }
+    }
+
+    const contests = await db
+      .select()
+      .from(cmContests)
+      .where(eq(cmContests.roundId, round.id));
+    for (const c of contests) {
+      await rerankContest(db, c.id);
+    }
+  }
+}
+
+/**
+ * Hook from match-lifecycle.onPhaseTransition: when a match's phase changes,
+ * advance the status of any CM rounds containing it.
+ *
+ *   pre_match    → refresh player pool (playing XI may now be known), round → open
+ *   live         → round → live (and previously, open → locked at lockTime)
+ *   completed    → if all matches in the round are complete, settle the round
+ *
+ * This ties CM into the same lifecycle pipeline as every other format, so admins
+ * never have to touch CM-specific controls.
+ */
+export async function onMatchPhaseTransition(
+  db: Database,
+  matchId: string,
+  toPhase: string
+) {
+  const rounds = await db
+    .select()
+    .from(cmRounds)
+    .where(sql`${cmRounds.matchIds} @> ${JSON.stringify([matchId])}::jsonb`);
+
+  for (const round of rounds) {
+    if (round.status === "settled" || round.status === "void") continue;
+
+    try {
+      // pre_match: refresh player pool (playing XI likely just posted) so
+      // entries built before the XI announcement get the latest info.
+      // Round status does NOT transition here — entries remain open until
+      // the first match actually goes live.
+      if (toPhase === "pre_match") {
+        try {
+          await populateRoundPlayerPool(db, round.id);
+        } catch (err) {
+          log.warn(
+            { err, roundId: round.id },
+            "pre_match pool refresh failed"
+          );
+        }
+      }
+
+      // live: first match in the round just started → round → live,
+      // entries freeze. Only the FIRST live transition flips the round;
+      // subsequent live events are no-ops.
+      if (toPhase === "live") {
+        if (
+          round.status === "upcoming" ||
+          round.status === "open" ||
+          round.status === "locked"
+        ) {
+          await db
+            .update(cmRounds)
+            .set({ status: "live", updatedAt: new Date() })
+            .where(eq(cmRounds.id, round.id));
+          await db
+            .update(cmContests)
+            .set({ status: "live", updatedAt: new Date() })
+            .where(eq(cmContests.roundId, round.id));
+          log.info(
+            { roundId: round.id, matchId },
+            "CM round → live (first match live)"
+          );
+
+          // Notify members that entries are now locked + round is live
+          try {
+            await notifyLeagueMembers(
+              db,
+              round.leagueId,
+              NOTIFICATION_TYPES.STATUS_ALERT,
+              `${round.name} is live!`,
+              "entries are locked. watch your NRR climb as matches play out.",
+              { type: "cm_round_live", roundId: round.id }
+            );
+          } catch (err) {
+            log.warn({ err, roundId: round.id }, "round-live notify failed");
+          }
+        }
+      }
+
+      // completed: bump matches counter, settle if this was the last one.
+      if (toPhase === "completed") {
+        const matchRows = await db
+          .select()
+          .from(matches)
+          .where(inArray(matches.id, round.matchIds));
+        const completedCount = matchRows.filter(
+          (m) => m.status === "completed" || m.status === "abandoned"
+        ).length;
+
+        // Always keep matchesCompleted fresh so the round hub can show "3/7 done"
+        if (completedCount !== round.matchesCompleted) {
+          await db
+            .update(cmRounds)
+            .set({
+              matchesCompleted: completedCount,
+              updatedAt: new Date(),
+            })
+            .where(eq(cmRounds.id, round.id));
+        }
+
+        if (completedCount === matchRows.length && round.status !== "settled") {
+          await settleRound(db, round.id);
+          log.info(
+            { roundId: round.id, matchId },
+            "CM round settled (all matches complete)"
+          );
+        }
+      }
+    } catch (err) {
+      log.error(
+        { err, roundId: round.id, matchId, toPhase },
+        "CM onMatchPhaseTransition failed for round"
+      );
+    }
+  }
+}
+
+// ─── Lifecycle transitions (manual/cron fallback) ─────────────────────
+
+/**
+ * Reconcile round statuses against their match states + pre-phase any
+ * upcoming matches that should be in `pre_match` now (start time within 24h).
+ * Called from:
+ *   - score-updater pipeline (after every score refresh)
+ *   - admin `cricketManager.tickLifecycles` mutation
+ *   - standalone cron (future)
+ *
+ * Two passes in order:
+ *
+ * Pass 1 — Time-based match phase-up:
+ *   - Any match `status=upcoming, match_phase=idle, start_time < now + 24h`
+ *     → applyMatchPhaseChange(..., "pre_match") which fires all side-effects
+ *     (draft enablement, contest flips, user notifications, CM pool refresh)
+ *
+ * Pass 2 — CM round reconciliation:
+ *   - upcoming | locked → open (legacy rows; nothing sets these going forward)
+ *   - any non-live round with ≥1 match live/completed → live
+ *   - live round with zero live/completed matches → demote to open (rollbacks)
+ *   - live round with all matches complete → settle
+ */
+export async function tickRoundLifecycles(db: Database) {
+  const now = new Date();
+  const in24h = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+
+  // ── Pass 1: pre-phase upcoming matches to pre_match if start is within 24h
+  try {
+    const toPhaseUp = await db
+      .select({ id: matches.id, teamHome: matches.teamHome, teamAway: matches.teamAway })
+      .from(matches)
+      .where(
+        and(
+          eq(matches.status, "upcoming"),
+          eq(matches.matchPhase, "idle"),
+          sql`${matches.startTime} < ${in24h}`
+        )
+      );
+
+    if (toPhaseUp.length > 0) {
+      // Dynamic import to avoid circular dep: cm-service ↔ match-lifecycle
+      const { applyMatchPhaseChange } = await import("./match-lifecycle");
+      for (const m of toPhaseUp) {
+        try {
+          await applyMatchPhaseChange(db, m.id, "pre_match", "tick:auto_pre_match");
+          log.info(
+            { matchId: m.id, match: `${m.teamHome} vs ${m.teamAway}` },
+            "tick: match auto-transitioned idle → pre_match (24h window)"
+          );
+        } catch (err) {
+          log.error({ err, matchId: m.id }, "tick: auto pre_match failed");
+        }
+      }
+    }
+  } catch (err) {
+    log.error({ err }, "tick: pre_match scan failed");
+  }
+
+  // ── Pass 2: CM round reconciliation
+  // Fetch all non-terminal rounds
+  const rounds = await db
+    .select()
+    .from(cmRounds)
+    .where(
+      inArray(cmRounds.status, ["upcoming", "open", "locked", "live"])
+    );
+
+  for (const r of rounds) {
+    try {
+      const matchRows = await db
+        .select()
+        .from(matches)
+        .where(inArray(matches.id, r.matchIds));
+
+      const liveCount = matchRows.filter((m) => m.status === "live").length;
+      const completedCount = matchRows.filter(
+        (m) => m.status === "completed" || m.status === "abandoned"
+      ).length;
+      const totalMatches = matchRows.length;
+
+      // Refresh matchesCompleted counter
+      if (completedCount !== r.matchesCompleted) {
+        await db
+          .update(cmRounds)
+          .set({ matchesCompleted: completedCount, updatedAt: new Date() })
+          .where(eq(cmRounds.id, r.id));
+      }
+
+      // All matches done → settle
+      if (totalMatches > 0 && completedCount === totalMatches) {
+        if (r.status !== "settled") {
+          try {
+            await settleRound(db, r.id);
+            log.info({ roundId: r.id }, "tick: round settled");
+          } catch (err) {
+            log.error({ err, roundId: r.id }, "tick: settle failed");
+          }
+        }
+        continue;
+      }
+
+      // Any match live or completed → round is live
+      const shouldBeLive = liveCount > 0 || completedCount > 0;
+
+      if (shouldBeLive && r.status !== "live") {
+        await db
+          .update(cmRounds)
+          .set({ status: "live", updatedAt: new Date() })
+          .where(eq(cmRounds.id, r.id));
+        await db
+          .update(cmContests)
+          .set({ status: "live", updatedAt: new Date() })
+          .where(eq(cmContests.roundId, r.id));
+        log.info({ roundId: r.id }, "tick: round → live");
+        continue;
+      }
+
+      // No live/completed matches → round is open (for editing)
+      if (!shouldBeLive && r.status !== "open") {
+        await db
+          .update(cmRounds)
+          .set({ status: "open", updatedAt: new Date() })
+          .where(eq(cmRounds.id, r.id));
+        await db
+          .update(cmContests)
+          .set({ status: "open", updatedAt: new Date() })
+          .where(eq(cmContests.roundId, r.id));
+        log.info({ roundId: r.id }, "tick: round → open");
+      }
+    } catch (err) {
+      log.error({ err, roundId: r.id }, "tickRoundLifecycles failed");
+    }
+  }
+}
+
+// ─── Settlement ────────────────────────────────────────────────────────
+
+export async function settleRound(db: Database, roundId: string) {
+  const round = await db.query.cmRounds.findFirst({
+    where: eq(cmRounds.id, roundId),
+  });
+  if (!round)
+    throw new TRPCError({ code: "NOT_FOUND", message: "Round not found" });
+
+  // Final simulation pass
+  const entries = await db
+    .select()
+    .from(cmEntries)
+    .where(eq(cmEntries.roundId, roundId));
+  for (const e of entries) {
+    try {
+      await runEntrySimulation(db, e.id);
+    } catch (err) {
+      log.error({ err, entryId: e.id }, "Final sim failed");
+    }
+  }
+
+  // Rerank each contest + pay out prizes
+  const contests = await db
+    .select()
+    .from(cmContests)
+    .where(eq(cmContests.roundId, roundId));
+
+  for (const c of contests) {
+    await rerankContest(db, c.id);
+
+    if (c.prizePool > 0) {
+      const ranked = await db
+        .select({
+          userId: cmContestMembers.userId,
+          rank: cmContestMembers.rank,
+        })
+        .from(cmContestMembers)
+        .where(eq(cmContestMembers.contestId, c.id));
+
+      const distribution = c.prizeDistribution as Array<{
+        rank: number;
+        percent: number;
+      }>;
+      for (const d of distribution) {
+        const winner = ranked.find((r) => r.rank === d.rank);
+        if (winner) {
+          const prize = Math.round((c.prizePool * d.percent) / 100);
+          if (prize > 0) {
+            try {
+              await awardCoins(db, winner.userId, prize, "cm_contest_win", {
+                contestId: c.id,
+                roundId,
+                rank: d.rank,
+              });
+              await db
+                .update(cmContestMembers)
+                .set({ prizeWon: prize })
+                .where(
+                  and(
+                    eq(cmContestMembers.contestId, c.id),
+                    eq(cmContestMembers.userId, winner.userId)
+                  )
+                );
+            } catch (err) {
+              log.error(
+                { err, userId: winner.userId, contestId: c.id },
+                "Failed to award prize"
+              );
+            }
+          }
+        }
+      }
+    }
+
+    await db
+      .update(cmContests)
+      .set({ status: "settled", updatedAt: new Date() })
+      .where(eq(cmContests.id, c.id));
+  }
+
+  // Update league standings — win metric fix (battingTotal > bowlingTotal)
+  // + streak tracking + losses + worst/avg NRR.
+  for (const e of entries) {
+    // A "win" is when batting beat bowling (spec §7.4).
+    // For bowl_first chases, batting >= bowling +1 means we reached the target.
+    // For bat_first, batting > bowling is the natural rule.
+    const won = e.battingTotal > e.bowlingTotal;
+    const nrrNum = Number(e.nrr);
+
+    // Load existing standing to compute streak + avg correctly
+    const existing = await db.query.cmLeagueStandings.findFirst({
+      where: and(
+        eq(cmLeagueStandings.leagueId, round.leagueId),
+        eq(cmLeagueStandings.userId, e.userId)
+      ),
+    });
+
+    if (!existing) {
+      await db.insert(cmLeagueStandings).values({
+        leagueId: round.leagueId,
+        userId: e.userId,
+        totalNrr: nrrNum.toFixed(4),
+        roundsPlayed: 1,
+        wins: won ? 1 : 0,
+        losses: won ? 0 : 1,
+        bestNrr: nrrNum.toFixed(4),
+        worstNrr: nrrNum.toFixed(4),
+        avgNrr: nrrNum.toFixed(4),
+        currentWinStreak: won ? 1 : 0,
+        bestWinStreak: won ? 1 : 0,
+      });
+    } else {
+      const newRounds = existing.roundsPlayed + 1;
+      const newTotal = Number(existing.totalNrr) + nrrNum;
+      const newWins = existing.wins + (won ? 1 : 0);
+      const newLosses = existing.losses + (won ? 0 : 1);
+      const newCurrentStreak = won ? existing.currentWinStreak + 1 : 0;
+      const newBestStreak = Math.max(existing.bestWinStreak, newCurrentStreak);
+      const newBest = Math.max(Number(existing.bestNrr ?? -Infinity), nrrNum);
+      const newWorst = Math.min(Number(existing.worstNrr ?? Infinity), nrrNum);
+      const newAvg = newTotal / newRounds;
+
+      await db
+        .update(cmLeagueStandings)
+        .set({
+          totalNrr: newTotal.toFixed(4),
+          roundsPlayed: newRounds,
+          wins: newWins,
+          losses: newLosses,
+          bestNrr: newBest.toFixed(4),
+          worstNrr: newWorst.toFixed(4),
+          avgNrr: newAvg.toFixed(4),
+          currentWinStreak: newCurrentStreak,
+          bestWinStreak: newBestStreak,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(cmLeagueStandings.leagueId, round.leagueId),
+            eq(cmLeagueStandings.userId, e.userId)
+          )
+        );
+    }
+  }
+
+  // Rerank league season leaderboard
+  await rerankLeagueStandings(db, round.leagueId);
+
+  // Award round-level badges (Master Manager, Bowling Masterclass, 10-win streak)
+  try {
+    await awardRoundBadges(db, round, entries);
+  } catch (err) {
+    log.error({ err, roundId }, "Failed to award round badges");
+  }
+
+  // Round stats
+  const nrrs = entries.map((e) => Number(e.nrr));
+  const avgNrr =
+    nrrs.length > 0 ? nrrs.reduce((s, n) => s + n, 0) / nrrs.length : 0;
+  const bestNrr = nrrs.length > 0 ? Math.max(...nrrs) : 0;
+
+  await db
+    .update(cmRounds)
+    .set({
+      status: "settled",
+      totalEntries: entries.length,
+      avgNrr: avgNrr.toFixed(4),
+      bestNrr: bestNrr.toFixed(4),
+      matchesCompleted: round.matchesTotal,
+      updatedAt: new Date(),
+    })
+    .where(eq(cmRounds.id, roundId));
+
+  // Notify participants with their final rank + prize
+  try {
+    await notifyRoundSettled(db, round, entries);
+  } catch (err) {
+    log.warn({ err, roundId }, "settlement notify failed");
+  }
+
+  // Check if the whole league is now done (all rounds settled)
+  try {
+    await maybeSettleLeague(db, round.leagueId);
+  } catch (err) {
+    log.error({ err, leagueId: round.leagueId }, "league settle check failed");
+  }
+
+  log.info({ roundId, entries: entries.length }, "CM round settled");
+}
+
+// ─── Helpers: notifications, awards, league-level settlement ──────────
+
+async function notifyLeagueMembers(
+  db: Database,
+  leagueId: string,
+  type: "deadline_reminder" | "status_alert" | "contest_result" | "rank_change" | "tournament_award",
+  title: string,
+  body: string,
+  data?: Record<string, unknown>
+) {
+  const members = await db
+    .select({ userId: leagueMembers.userId })
+    .from(leagueMembers)
+    .where(eq(leagueMembers.leagueId, leagueId));
+  if (members.length === 0) return;
+  await sendBatchNotifications(
+    db,
+    members.map((m) => m.userId),
+    type,
+    title,
+    body,
+    data
+  );
+}
+
+async function notifyRoundSettled(
+  db: Database,
+  round: typeof cmRounds.$inferSelect,
+  entries: Array<typeof cmEntries.$inferSelect>
+) {
+  if (entries.length === 0) return;
+
+  // Get each user's rank + prize in the round's mega contest
+  const megaContest = await db.query.cmContests.findFirst({
+    where: and(
+      eq(cmContests.roundId, round.id),
+      eq(cmContests.contestType, "mega")
+    ),
+  });
+  const membersMap = new Map<string, { rank: number | null; prizeWon: number }>();
+  if (megaContest) {
+    const rows = await db
+      .select({
+        userId: cmContestMembers.userId,
+        rank: cmContestMembers.rank,
+        prizeWon: cmContestMembers.prizeWon,
+      })
+      .from(cmContestMembers)
+      .where(eq(cmContestMembers.contestId, megaContest.id));
+    for (const r of rows) {
+      membersMap.set(r.userId, { rank: r.rank, prizeWon: r.prizeWon });
+    }
+  }
+
+  // Group users into "winners" and "participants" for distinct messaging
+  for (const e of entries) {
+    const info = membersMap.get(e.userId);
+    const rank = info?.rank ?? "—";
+    const prize = info?.prizeWon ?? 0;
+    const nrr = Number(e.nrr).toFixed(2);
+    const title =
+      prize > 0
+        ? `${round.name} — you won ${prize} PC!`
+        : `${round.name} results are in`;
+    const body =
+      prize > 0
+        ? `finished #${rank} with NRR ${nrr}. prize credited to your wallet.`
+        : `finished #${rank} with NRR ${nrr}. check the leaderboard for winners.`;
+    await sendBatchNotifications(
+      db,
+      [e.userId],
+      NOTIFICATION_TYPES.CONTEST_RESULT,
+      title,
+      body,
+      {
+        type: "cm_round_settled",
+        roundId: round.id,
+        leagueId: round.leagueId,
+        rank,
+        prize,
+        nrr,
+      }
+    );
+  }
+}
+
+/**
+ * Emit round-level awards per the spec (§13.7):
+ *  - Master Manager: NRR > 5.0 in a single round
+ *  - Bowling Masterclass: 10 wickets in bowling simulation
+ *  - Tactician: top 10% of the round's contest
+ *  - Unbeaten: 10-round win streak
+ */
+async function awardRoundBadges(
+  db: Database,
+  round: typeof cmRounds.$inferSelect,
+  entries: Array<typeof cmEntries.$inferSelect>
+) {
+  // Count how many in the top 10% — ceiling of size/10, min 1
+  const top10Threshold = Math.max(1, Math.ceil(entries.length / 10));
+
+  // Fetch ranks for tactician check
+  const megaContest = await db.query.cmContests.findFirst({
+    where: and(
+      eq(cmContests.roundId, round.id),
+      eq(cmContests.contestType, "mega")
+    ),
+  });
+  const rankByUser = new Map<string, number>();
+  if (megaContest) {
+    const rows = await db
+      .select({
+        userId: cmContestMembers.userId,
+        rank: cmContestMembers.rank,
+      })
+      .from(cmContestMembers)
+      .where(eq(cmContestMembers.contestId, megaContest.id));
+    for (const r of rows) {
+      if (r.rank != null) rankByUser.set(r.userId, r.rank);
+    }
+  }
+
+  const awardsToInsert: Array<{
+    leagueId: string;
+    roundNumber: number;
+    awardType: string;
+    userId: string;
+    details: Record<string, unknown>;
+  }> = [];
+
+  for (const e of entries) {
+    const nrrNum = Number(e.nrr);
+    // Master Manager — NRR > 5.0
+    if (nrrNum > 5.0) {
+      awardsToInsert.push({
+        leagueId: round.leagueId,
+        roundNumber: round.roundNumber,
+        awardType: "cm_master_manager",
+        userId: e.userId,
+        details: { nrr: nrrNum.toFixed(2), round: round.name },
+      });
+    }
+    // Bowling Masterclass — bowling side took 10 wickets
+    if (e.bowlingWickets >= 10) {
+      awardsToInsert.push({
+        leagueId: round.leagueId,
+        roundNumber: round.roundNumber,
+        awardType: "cm_bowling_masterclass",
+        userId: e.userId,
+        details: {
+          wickets: e.bowlingWickets,
+          conceded: e.bowlingTotal,
+          round: round.name,
+        },
+      });
+    }
+    // Tactician — top 10% of contest
+    const rank = rankByUser.get(e.userId);
+    if (rank != null && rank <= top10Threshold) {
+      awardsToInsert.push({
+        leagueId: round.leagueId,
+        roundNumber: round.roundNumber,
+        awardType: "cm_tactician",
+        userId: e.userId,
+        details: { rank, totalEntries: entries.length, round: round.name },
+      });
+    }
+  }
+
+  // Unbeaten — check who's on a 10-round win streak after this round
+  const streakRows = await db
+    .select()
+    .from(cmLeagueStandings)
+    .where(
+      and(
+        eq(cmLeagueStandings.leagueId, round.leagueId),
+        sql`${cmLeagueStandings.currentWinStreak} >= 10`
+      )
+    );
+  for (const s of streakRows) {
+    // Only award if they don't already have it for this round
+    awardsToInsert.push({
+      leagueId: round.leagueId,
+      roundNumber: round.roundNumber,
+      awardType: "cm_unbeaten",
+      userId: s.userId,
+      details: { winStreak: s.currentWinStreak, round: round.name },
+    });
+  }
+
+  if (awardsToInsert.length > 0) {
+    await db.insert(leagueAwards).values(awardsToInsert);
+
+    // Push notify winners of each award
+    const notifyUsers = new Set(awardsToInsert.map((a) => a.userId));
+    const uniqueAwardsByUser = new Map<string, string[]>();
+    for (const a of awardsToInsert) {
+      const arr = uniqueAwardsByUser.get(a.userId) ?? [];
+      arr.push(a.awardType);
+      uniqueAwardsByUser.set(a.userId, arr);
+    }
+    for (const userId of notifyUsers) {
+      const awards = uniqueAwardsByUser.get(userId) ?? [];
+      const label = awards
+        .map((t) => awardLabel(t))
+        .join(", ");
+      await sendBatchNotifications(
+        db,
+        [userId],
+        NOTIFICATION_TYPES.TOURNAMENT_AWARD,
+        `Award unlocked: ${label}`,
+        `nice one — you earned ${awards.length > 1 ? "awards" : "an award"} in ${round.name}.`,
+        {
+          type: "cm_award",
+          roundId: round.id,
+          leagueId: round.leagueId,
+          awards,
+        }
+      );
+    }
+  }
+}
+
+function awardLabel(awardType: string): string {
+  switch (awardType) {
+    case "cm_master_manager":
+      return "Master Manager";
+    case "cm_bowling_masterclass":
+      return "Bowling Masterclass";
+    case "cm_tactician":
+      return "Tactician";
+    case "cm_unbeaten":
+      return "Unbeaten";
+    case "cm_season_champion":
+      return "Season Champion";
+    default:
+      return awardType;
+  }
+}
+
+/**
+ * Check if a league is done (all rounds settled). If so, distribute the
+ * `finalPct` share of the prize pool to the top-ranked users in
+ * `cm_league_standings`, award Season Champion, and mark the league settled.
+ */
+async function maybeSettleLeague(db: Database, leagueId: string) {
+  const league = await db.query.leagues.findFirst({
+    where: eq(leagues.id, leagueId),
+  });
+  if (!league || league.format !== "cricket_manager") return;
+  if (league.status === "completed" || league.status === "archived") return;
+
+  const allRounds = await db
+    .select({ id: cmRounds.id, status: cmRounds.status })
+    .from(cmRounds)
+    .where(eq(cmRounds.leagueId, leagueId));
+
+  if (allRounds.length === 0) return;
+  const allSettled = allRounds.every(
+    (r) => r.status === "settled" || r.status === "void"
+  );
+  if (!allSettled) return;
+
+  const rules = (league.rules ?? {}) as LeagueRules;
+  const cm = rules.cricketManager ?? {};
+  const prizePool = cm.prizePool ?? 0;
+  const finalPct = cm.roundPrizeSplit?.finalPct ?? 0;
+  const finalPool = Math.round((prizePool * finalPct) / 100);
+  const prizeDist = cm.prizeDistribution ?? [
+    { rank: 1, percent: 50 },
+    { rank: 2, percent: 30 },
+    { rank: 3, percent: 20 },
+  ];
+
+  // Distribute final pool based on season standings
+  if (finalPool > 0 && prizeDist.length > 0) {
+    const standings = await db
+      .select()
+      .from(cmLeagueStandings)
+      .where(eq(cmLeagueStandings.leagueId, leagueId))
+      .orderBy(
+        sql`${cmLeagueStandings.currentRank} NULLS LAST`,
+        desc(cmLeagueStandings.totalNrr)
+      );
+
+    for (const d of prizeDist) {
+      const winner = standings[d.rank - 1];
+      if (!winner) continue;
+      const prize = Math.round((finalPool * d.percent) / 100);
+      if (prize <= 0) continue;
+
+      try {
+        await awardCoins(db, winner.userId, prize, "cm_season_reward", {
+          leagueId,
+          rank: d.rank,
+        });
+        await db
+          .update(cmLeagueStandings)
+          .set({
+            prizeWon: sql`${cmLeagueStandings.prizeWon} + ${prize}`,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(cmLeagueStandings.leagueId, leagueId),
+              eq(cmLeagueStandings.userId, winner.userId)
+            )
+          );
+
+        // Season Champion award for rank 1
+        if (d.rank === 1) {
+          await db.insert(leagueAwards).values({
+            leagueId,
+            awardType: "cm_season_champion",
+            userId: winner.userId,
+            details: {
+              totalNrr: Number(winner.totalNrr).toFixed(2),
+              wins: winner.wins,
+              prize,
+            },
+          });
+        }
+      } catch (err) {
+        log.error(
+          { err, userId: winner.userId, leagueId },
+          "Failed to pay final season prize"
+        );
+      }
+    }
+  }
+
+  // Mark league completed
+  await db
+    .update(leagues)
+    .set({ status: "completed" })
+    .where(eq(leagues.id, leagueId));
+
+  // Notify all members
+  try {
+    await notifyLeagueMembers(
+      db,
+      leagueId,
+      "tournament_award",
+      `${league.name} has ended`,
+      "the final standings are in. check your season rank and prizes.",
+      { type: "cm_league_settled", leagueId }
+    );
+  } catch (err) {
+    log.warn({ err, leagueId }, "league settled notify failed");
+  }
+
+  log.info({ leagueId, finalPool }, "CM league settled");
+}
+
+/**
+ * Join a CM league, charging the one-time entry fee from rules.cricketManager.entryFee.
+ * Used by the mobile "Join Mega League" flow to keep the economy honest.
+ */
+export async function joinCmLeague(
+  db: Database,
+  userId: string,
+  leagueId: string
+) {
+  const league = await db.query.leagues.findFirst({
+    where: eq(leagues.id, leagueId),
+  });
+  if (!league) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "League not found" });
+  }
+  if (league.format !== "cricket_manager") {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "League is not a Cricket Manager league",
+    });
+  }
+  if (league.status === "completed") {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "League has already ended",
+    });
+  }
+
+  const existing = await db.query.leagueMembers.findFirst({
+    where: and(
+      eq(leagueMembers.leagueId, leagueId),
+      eq(leagueMembers.userId, userId)
+    ),
+  });
+  if (existing) {
+    throw new TRPCError({ code: "CONFLICT", message: "Already a member" });
+  }
+
+  const memberCountRows = await db
+    .select({ c: sql<number>`count(*)::int` })
+    .from(leagueMembers)
+    .where(eq(leagueMembers.leagueId, leagueId));
+  if ((memberCountRows[0]?.c ?? 0) >= league.maxMembers) {
+    throw new TRPCError({ code: "BAD_REQUEST", message: "League is full" });
+  }
+
+  const rules = (league.rules ?? {}) as LeagueRules;
+  const entryFee = rules.cricketManager?.entryFee ?? 0;
+
+  // Charge entry fee once (mega-league model: covers all rounds)
+  if (entryFee > 0) {
+    await deductCoins(db, userId, entryFee, "cm_league_entry", {
+      leagueId,
+    });
+  }
+
+  await db.insert(leagueMembers).values({
+    leagueId,
+    userId,
+    role: "member",
+  });
+
+  log.info({ userId, leagueId, entryFee }, "User joined CM league");
+  return league;
+}
+
+async function rerankLeagueStandings(db: Database, leagueId: string) {
+  const standings = await db
+    .select()
+    .from(cmLeagueStandings)
+    .where(eq(cmLeagueStandings.leagueId, leagueId))
+    .orderBy(desc(cmLeagueStandings.totalNrr));
+
+  for (let i = 0; i < standings.length; i++) {
+    const s = standings[i]!;
+    await db
+      .update(cmLeagueStandings)
+      .set({ currentRank: i + 1 })
+      .where(
+        and(
+          eq(cmLeagueStandings.leagueId, leagueId),
+          eq(cmLeagueStandings.userId, s.userId)
+        )
+      );
+  }
+}

--- a/packages/api/src/services/match-lifecycle.ts
+++ b/packages/api/src/services/match-lifecycle.ts
@@ -17,6 +17,7 @@ import { lockMatchContests, completeMatch } from "../jobs/score-updater";
 import { settleMatchContests } from "../jobs/settle-contest";
 import { sendBatchNotifications } from "./notifications";
 import { autoCloseMatchPredictions, autoAbandonUnresolvedPredictions } from "./live-predictions";
+import { onMatchPhaseTransition as cmOnMatchPhaseTransition } from "./cm-service";
 import { getLogger } from "../lib/logger";
 
 const log = getLogger("match-lifecycle");
@@ -47,6 +48,70 @@ async function getMatchParticipantUserIds(db: Database, matchId: string): Promis
   });
 
   return [...new Set(teams.map(t => t.userId))];
+}
+
+/**
+ * Canonical "change a match's phase" helper. Every code path that needs to
+ * alter `matches.match_phase` — admin mutations, refresh jobs, background
+ * fetches, automated ticks — MUST go through this function. It:
+ *
+ *   1. Reads the current phase (so this is idempotent — no-op on same phase)
+ *   2. Writes the new phase to the matches table
+ *   3. Calls onPhaseTransition() to fire every downstream side-effect
+ *      (draft enablement, contest status flips, notifications, CM hooks,
+ *       prediction grace periods, settlement)
+ *
+ * Prior to this helper, refresh/background paths silently wrote
+ * `match_phase` directly and skipped side-effects — leading to "drafts open
+ * but no users notified", "contests stuck at upcoming", "CM rounds never
+ * transitioning", etc. Never write to matches.match_phase without calling
+ * this function.
+ *
+ * @param source free-form label for logs — e.g. "admin:updatePhase",
+ *               "refresh:refreshMatch", "tick:idle_to_pre_match"
+ */
+export async function applyMatchPhaseChange(
+  db: Database,
+  matchId: string,
+  toPhase: string,
+  source: string
+): Promise<PhaseTransitionResult | null> {
+  const match = await db.query.matches.findFirst({
+    where: eq(matches.id, matchId),
+    columns: { id: true, matchPhase: true },
+  });
+  if (!match) {
+    log.warn({ matchId, source }, "applyMatchPhaseChange: match not found");
+    return null;
+  }
+
+  const fromPhase = match.matchPhase ?? "idle";
+  if (fromPhase === toPhase) {
+    // No-op — phase already at target
+    return { fromPhase, toPhase, actions: [] };
+  }
+
+  // Persist the phase change
+  await db
+    .update(matches)
+    .set({ matchPhase: toPhase })
+    .where(eq(matches.id, matchId));
+
+  log.info(
+    { matchId, fromPhase, toPhase, source },
+    "Match phase updated"
+  );
+
+  // Fire all downstream side-effects
+  try {
+    return await onPhaseTransition(db, matchId, fromPhase, toPhase);
+  } catch (err) {
+    log.error(
+      { err, matchId, fromPhase, toPhase, source },
+      "onPhaseTransition failed after phase change"
+    );
+    return { fromPhase, toPhase, actions: ["phase-transition-error"] };
+  }
 }
 
 /**
@@ -263,6 +328,19 @@ export async function onPhaseTransition(
     actions.push("Draft disabled, deadline cleared");
 
     log.info({ matchId, matchLabel, actions }, "Phase → idle");
+  }
+
+  // Cricket Manager rounds piggyback on the same phase transitions:
+  //  - pre_match: refresh player pool + open the round
+  //  - live:      lock entries, round → live
+  //  - completed: settle the round if this was its last match
+  try {
+    await cmOnMatchPhaseTransition(db, matchId, toPhase);
+  } catch (err) {
+    log.warn(
+      { matchId, toPhase, err: String(err) },
+      "CM phase transition hook failed (non-fatal)"
+    );
   }
 
   return { fromPhase, toPhase, actions };

--- a/packages/db/src/migrations/0020_cricket_manager.sql
+++ b/packages/db/src/migrations/0020_cricket_manager.sql
@@ -1,0 +1,237 @@
+-- Cricket Manager — round-based fantasy format layered on the `leagues` table.
+-- Leagues with format = 'cricket_manager' are managed via this schema.
+-- Spec: /docs/CRICKET_MANAGER_DRAFT.md
+-- Idempotent: safe to re-run; uses IF NOT EXISTS where possible.
+
+-- ─── Rounds ─────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS "cm_rounds" (
+  "id"                    uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "league_id"             uuid NOT NULL,
+  "tournament_id"         uuid,
+  "round_number"          integer NOT NULL,
+  "name"                  text NOT NULL,
+  "status"                text NOT NULL DEFAULT 'upcoming',
+  "match_ids"             jsonb NOT NULL DEFAULT '[]'::jsonb,
+  "window_start"          timestamp with time zone NOT NULL,
+  "window_end"            timestamp with time zone NOT NULL,
+  "lock_time"             timestamp with time zone NOT NULL,
+  "eligible_players"      jsonb NOT NULL DEFAULT '[]'::jsonb,
+  "ball_limit"            integer NOT NULL DEFAULT 120,
+  "min_bowlers"           integer NOT NULL DEFAULT 5,
+  "max_overs_per_bowler"  integer NOT NULL DEFAULT 4,
+  "matches_completed"     integer NOT NULL DEFAULT 0,
+  "matches_total"         integer NOT NULL DEFAULT 0,
+  "total_entries"         integer NOT NULL DEFAULT 0,
+  "avg_nrr"               numeric(8,4),
+  "best_nrr"              numeric(8,4),
+  "created_at"            timestamp with time zone NOT NULL DEFAULT now(),
+  "updated_at"            timestamp with time zone NOT NULL DEFAULT now()
+);
+
+DO $$ BEGIN
+  ALTER TABLE "cm_rounds"
+    ADD CONSTRAINT "cm_rounds_league_fk"
+    FOREIGN KEY ("league_id") REFERENCES "public"."leagues"("id")
+    ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "cm_rounds"
+    ADD CONSTRAINT "cm_rounds_tournament_fk"
+    FOREIGN KEY ("tournament_id") REFERENCES "public"."tournaments"("id")
+    ON DELETE no action ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE INDEX IF NOT EXISTS "idx_cm_rounds_league"     ON "cm_rounds" ("league_id");
+CREATE INDEX IF NOT EXISTS "idx_cm_rounds_tournament" ON "cm_rounds" ("tournament_id");
+CREATE INDEX IF NOT EXISTS "idx_cm_rounds_status"     ON "cm_rounds" ("status");
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_cm_rounds_number" ON "cm_rounds" ("league_id","round_number");
+
+-- ─── Contests ───────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS "cm_contests" (
+  "id"                  uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "round_id"            uuid NOT NULL,
+  "league_id"           uuid NOT NULL,
+  "name"                text NOT NULL,
+  "contest_type"        text NOT NULL DEFAULT 'mega',
+  "entry_fee"           integer NOT NULL DEFAULT 0,
+  "prize_pool"          integer NOT NULL DEFAULT 0,
+  "prize_distribution"  jsonb NOT NULL DEFAULT '[]'::jsonb,
+  "max_members"         integer NOT NULL DEFAULT 10000,
+  "current_members"     integer NOT NULL DEFAULT 0,
+  "invite_code"         text UNIQUE,
+  "status"              text NOT NULL DEFAULT 'upcoming',
+  "created_by"          uuid,
+  "created_at"          timestamp with time zone NOT NULL DEFAULT now(),
+  "updated_at"          timestamp with time zone NOT NULL DEFAULT now()
+);
+
+DO $$ BEGIN
+  ALTER TABLE "cm_contests"
+    ADD CONSTRAINT "cm_contests_round_fk"
+    FOREIGN KEY ("round_id") REFERENCES "public"."cm_rounds"("id")
+    ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "cm_contests"
+    ADD CONSTRAINT "cm_contests_league_fk"
+    FOREIGN KEY ("league_id") REFERENCES "public"."leagues"("id")
+    ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "cm_contests"
+    ADD CONSTRAINT "cm_contests_created_by_fk"
+    FOREIGN KEY ("created_by") REFERENCES "public"."users"("id")
+    ON DELETE no action ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE INDEX IF NOT EXISTS "idx_cm_contests_round"  ON "cm_contests" ("round_id");
+CREATE INDEX IF NOT EXISTS "idx_cm_contests_league" ON "cm_contests" ("league_id");
+CREATE INDEX IF NOT EXISTS "idx_cm_contests_status" ON "cm_contests" ("status");
+CREATE INDEX IF NOT EXISTS "idx_cm_contests_invite" ON "cm_contests" ("invite_code");
+
+-- ─── Entries ────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS "cm_entries" (
+  "id"                    uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "round_id"              uuid NOT NULL,
+  "user_id"               uuid NOT NULL,
+  "players"               jsonb NOT NULL,
+  "batting_order"         jsonb NOT NULL,
+  "bowling_priority"      jsonb NOT NULL,
+  "chip_used"             text,
+  "chip_target"           text,
+  "batting_total"         integer NOT NULL DEFAULT 0,
+  "batting_balls_used"    integer NOT NULL DEFAULT 0,
+  "batting_wickets"       integer NOT NULL DEFAULT 0,
+  "batting_details"       jsonb,
+  "bowling_total"         integer NOT NULL DEFAULT 0,
+  "bowling_balls_bowled"  integer NOT NULL DEFAULT 0,
+  "bowling_wickets"       integer NOT NULL DEFAULT 0,
+  "bowling_details"       jsonb,
+  "nrr"                   numeric(8,4) NOT NULL DEFAULT '0',
+  "batting_sr"            numeric(8,4) NOT NULL DEFAULT '0',
+  "submitted_at"          timestamp with time zone NOT NULL DEFAULT now(),
+  "updated_at"            timestamp with time zone NOT NULL DEFAULT now()
+);
+
+DO $$ BEGIN
+  ALTER TABLE "cm_entries"
+    ADD CONSTRAINT "cm_entries_round_fk"
+    FOREIGN KEY ("round_id") REFERENCES "public"."cm_rounds"("id")
+    ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "cm_entries"
+    ADD CONSTRAINT "cm_entries_user_fk"
+    FOREIGN KEY ("user_id") REFERENCES "public"."users"("id")
+    ON DELETE no action ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE INDEX IF NOT EXISTS "idx_cm_entries_round" ON "cm_entries" ("round_id");
+CREATE INDEX IF NOT EXISTS "idx_cm_entries_user"  ON "cm_entries" ("user_id");
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_cm_entries_round_user" ON "cm_entries" ("round_id","user_id");
+
+-- ─── Contest Members ────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS "cm_contest_members" (
+  "contest_id"  uuid NOT NULL,
+  "user_id"     uuid NOT NULL,
+  "entry_id"    uuid NOT NULL,
+  "rank"        integer,
+  "prize_won"   integer NOT NULL DEFAULT 0,
+  "joined_at"   timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT "cm_contest_members_pk" PRIMARY KEY ("contest_id","user_id")
+);
+
+DO $$ BEGIN
+  ALTER TABLE "cm_contest_members"
+    ADD CONSTRAINT "cm_cm_contest_fk"
+    FOREIGN KEY ("contest_id") REFERENCES "public"."cm_contests"("id")
+    ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "cm_contest_members"
+    ADD CONSTRAINT "cm_cm_user_fk"
+    FOREIGN KEY ("user_id") REFERENCES "public"."users"("id")
+    ON DELETE no action ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "cm_contest_members"
+    ADD CONSTRAINT "cm_cm_entry_fk"
+    FOREIGN KEY ("entry_id") REFERENCES "public"."cm_entries"("id")
+    ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE INDEX IF NOT EXISTS "idx_cm_cm_user" ON "cm_contest_members" ("user_id");
+CREATE INDEX IF NOT EXISTS "idx_cm_cm_rank" ON "cm_contest_members" ("contest_id","rank");
+
+-- ─── League Standings ──────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS "cm_league_standings" (
+  "league_id"     uuid NOT NULL,
+  "user_id"       uuid NOT NULL,
+  "total_nrr"     numeric(10,4) NOT NULL DEFAULT '0',
+  "rounds_played" integer NOT NULL DEFAULT 0,
+  "wins"          integer NOT NULL DEFAULT 0,
+  "best_nrr"      numeric(8,4),
+  "current_rank"  integer,
+  "prize_won"     integer NOT NULL DEFAULT 0,
+  "updated_at"    timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT "cm_league_standings_pk" PRIMARY KEY ("league_id","user_id")
+);
+
+DO $$ BEGIN
+  ALTER TABLE "cm_league_standings"
+    ADD CONSTRAINT "cm_ls_league_fk"
+    FOREIGN KEY ("league_id") REFERENCES "public"."leagues"("id")
+    ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "cm_league_standings"
+    ADD CONSTRAINT "cm_ls_user_fk"
+    FOREIGN KEY ("user_id") REFERENCES "public"."users"("id")
+    ON DELETE no action ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE INDEX IF NOT EXISTS "idx_cm_ls_user" ON "cm_league_standings" ("user_id");
+CREATE INDEX IF NOT EXISTS "idx_cm_ls_rank" ON "cm_league_standings" ("league_id","current_rank");
+
+-- ─── Chips ──────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS "cm_chips" (
+  "id"              uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "user_id"         uuid NOT NULL,
+  "tournament_id"   uuid NOT NULL,
+  "chip_type"       text NOT NULL,
+  "used_in_round"   uuid,
+  "used_at"         timestamp with time zone,
+  "created_at"      timestamp with time zone NOT NULL DEFAULT now()
+);
+
+DO $$ BEGIN
+  ALTER TABLE "cm_chips"
+    ADD CONSTRAINT "cm_chips_user_fk"
+    FOREIGN KEY ("user_id") REFERENCES "public"."users"("id")
+    ON DELETE no action ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "cm_chips"
+    ADD CONSTRAINT "cm_chips_tournament_fk"
+    FOREIGN KEY ("tournament_id") REFERENCES "public"."tournaments"("id")
+    ON DELETE no action ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "cm_chips"
+    ADD CONSTRAINT "cm_chips_used_round_fk"
+    FOREIGN KEY ("used_in_round") REFERENCES "public"."cm_rounds"("id")
+    ON DELETE no action ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_cm_chips_user_tournament_type"
+  ON "cm_chips" ("user_id","tournament_id","chip_type");
+CREATE INDEX IF NOT EXISTS "idx_cm_chips_user" ON "cm_chips" ("user_id");

--- a/packages/db/src/migrations/0021_cm_entries_toss.sql
+++ b/packages/db/src/migrations/0021_cm_entries_toss.sql
@@ -1,0 +1,6 @@
+-- Cricket Manager — add toss call column to entries
+-- Spec: /docs/CRICKET_MANAGER_DRAFT.md §2 (toss)
+-- Idempotent: safe to re-run.
+
+ALTER TABLE "cm_entries"
+  ADD COLUMN IF NOT EXISTS "toss" text NOT NULL DEFAULT 'bat_first';

--- a/packages/db/src/migrations/0022_cm_standings_streaks.sql
+++ b/packages/db/src/migrations/0022_cm_standings_streaks.sql
@@ -1,0 +1,19 @@
+-- Cricket Manager — extend league standings with streak + aggregate columns
+-- Enables #10 (season standings depth), #12 (win metric fix needs losses counter),
+-- and the "season champion" / "unbeaten" awards.
+-- Idempotent: safe to re-run.
+
+ALTER TABLE "cm_league_standings"
+  ADD COLUMN IF NOT EXISTS "losses" integer NOT NULL DEFAULT 0;
+
+ALTER TABLE "cm_league_standings"
+  ADD COLUMN IF NOT EXISTS "worst_nrr" numeric(8,4);
+
+ALTER TABLE "cm_league_standings"
+  ADD COLUMN IF NOT EXISTS "avg_nrr" numeric(8,4);
+
+ALTER TABLE "cm_league_standings"
+  ADD COLUMN IF NOT EXISTS "current_win_streak" integer NOT NULL DEFAULT 0;
+
+ALTER TABLE "cm_league_standings"
+  ADD COLUMN IF NOT EXISTS "best_win_streak" integer NOT NULL DEFAULT 0;

--- a/packages/db/src/schema/cricket-manager.ts
+++ b/packages/db/src/schema/cricket-manager.ts
@@ -1,0 +1,390 @@
+import {
+  pgTable,
+  uuid,
+  text,
+  integer,
+  decimal,
+  timestamp,
+  jsonb,
+  index,
+  unique,
+  primaryKey,
+} from "drizzle-orm/pg-core";
+import { relations } from "drizzle-orm";
+import { users } from "./users";
+import { tournaments } from "./tournaments";
+import { leagues } from "./contests";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cricket Manager — round-based fantasy format
+//
+// Leagues with format = 'cricket_manager' are managed via this schema.
+// The league itself (public admin-created or private user-created) lives in
+// the existing `leagues` table; `cm_rounds` hang off a league. This keeps
+// browsing, joining, membership, and invite codes unified with every other
+// league format.
+//
+// Spec: /docs/CRICKET_MANAGER_DRAFT.md
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Rounds — admin-composed groups of matches inside a league
+export const cmRounds = pgTable(
+  "cm_rounds",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    leagueId: uuid("league_id")
+      .notNull()
+      .references(() => leagues.id, { onDelete: "cascade" }),
+    tournamentId: uuid("tournament_id").references(() => tournaments.id),
+    roundNumber: integer("round_number").notNull(),
+    name: text("name").notNull(), // "Round 1 — Opening Fixtures"
+    status: text("status").notNull().default("upcoming"),
+    // upcoming, open, locked, live, settled, void
+
+    // Hand-picked match IDs (JSONB array of UUIDs)
+    matchIds: jsonb("match_ids").$type<string[]>().notNull().default([]),
+    windowStart: timestamp("window_start", { withTimezone: true }).notNull(),
+    windowEnd: timestamp("window_end", { withTimezone: true }).notNull(),
+    lockTime: timestamp("lock_time", { withTimezone: true }).notNull(),
+
+    // Player pool — populated when round transitions to open
+    eligiblePlayers: jsonb("eligible_players")
+      .$type<
+        Array<{
+          playerId: string;
+          name: string;
+          team: string;
+          role: string;
+          photoUrl?: string | null;
+          nationality?: string | null;
+          battingStyle?: string;
+          bowlingStyle?: string;
+          recentSr?: number;
+          recentAvg?: number;
+          recentEcon?: number;
+          recentBowlSr?: number;
+          formNote?: string | null;
+          recentForm?: number | null;
+        }>
+      >()
+      .notNull()
+      .default([]),
+
+    // Config (denormalized from league.rules.cricketManager for perf)
+    ballLimit: integer("ball_limit").notNull().default(120),
+    minBowlers: integer("min_bowlers").notNull().default(5),
+    maxOversPerBowler: integer("max_overs_per_bowler").notNull().default(4),
+
+    // Progress
+    matchesCompleted: integer("matches_completed").notNull().default(0),
+    matchesTotal: integer("matches_total").notNull().default(0),
+
+    // Stats (after settlement)
+    totalEntries: integer("total_entries").notNull().default(0),
+    avgNrr: decimal("avg_nrr", { precision: 8, scale: 4 }),
+    bestNrr: decimal("best_nrr", { precision: 8, scale: 4 }),
+
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_cm_rounds_league").on(table.leagueId),
+    index("idx_cm_rounds_tournament").on(table.tournamentId),
+    index("idx_cm_rounds_status").on(table.status),
+    unique("uq_cm_rounds_number").on(table.leagueId, table.roundNumber),
+  ]
+);
+
+// Contests — buckets of members competing on a round.
+// For v1, a single "mega" contest is auto-created per round at league publish time.
+export const cmContests = pgTable(
+  "cm_contests",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    roundId: uuid("round_id")
+      .notNull()
+      .references(() => cmRounds.id, { onDelete: "cascade" }),
+    leagueId: uuid("league_id")
+      .notNull()
+      .references(() => leagues.id, { onDelete: "cascade" }),
+
+    name: text("name").notNull(),
+    contestType: text("contest_type").notNull().default("mega"),
+    // mega, private, h2h, free
+
+    entryFee: integer("entry_fee").notNull().default(0),
+    prizePool: integer("prize_pool").notNull().default(0),
+    prizeDistribution: jsonb("prize_distribution")
+      .$type<Array<{ rank: number; percent: number }>>()
+      .notNull()
+      .default([]),
+
+    maxMembers: integer("max_members").notNull().default(10000),
+    currentMembers: integer("current_members").notNull().default(0),
+
+    inviteCode: text("invite_code").unique(),
+    status: text("status").notNull().default("upcoming"),
+    // upcoming, open, locked, live, settled
+
+    createdBy: uuid("created_by").references(() => users.id),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_cm_contests_round").on(table.roundId),
+    index("idx_cm_contests_league").on(table.leagueId),
+    index("idx_cm_contests_status").on(table.status),
+    index("idx_cm_contests_invite").on(table.inviteCode),
+  ]
+);
+
+// Entries — a member's squad + strategy + live/final simulation results.
+// One entry per (round, user). Shared across contests within the round.
+export const cmEntries = pgTable(
+  "cm_entries",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    roundId: uuid("round_id")
+      .notNull()
+      .references(() => cmRounds.id, { onDelete: "cascade" }),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id),
+
+    players: jsonb("players")
+      .$type<Array<{ playerId: string }>>()
+      .notNull(),
+    battingOrder: jsonb("batting_order")
+      .$type<Array<{ position: number; playerId: string }>>()
+      .notNull(),
+    bowlingPriority: jsonb("bowling_priority")
+      .$type<Array<{ priority: number; playerId: string }>>()
+      .notNull(),
+
+    chipUsed: text("chip_used"),
+    chipTarget: text("chip_target"),
+
+    // Toss call — "bat_first" means batters bat the full 120 balls,
+    // "bowl_first" means batters chase bowlTotal + 1 and stop when reached.
+    toss: text("toss").notNull().default("bat_first"),
+
+    // Batting sim
+    battingTotal: integer("batting_total").notNull().default(0),
+    battingBallsUsed: integer("batting_balls_used").notNull().default(0),
+    battingWickets: integer("batting_wickets").notNull().default(0),
+    battingDetails: jsonb("batting_details"),
+
+    // Bowling sim
+    bowlingTotal: integer("bowling_total").notNull().default(0),
+    bowlingBallsBowled: integer("bowling_balls_bowled").notNull().default(0),
+    bowlingWickets: integer("bowling_wickets").notNull().default(0),
+    bowlingDetails: jsonb("bowling_details"),
+
+    nrr: decimal("nrr", { precision: 8, scale: 4 }).notNull().default("0"),
+    battingSr: decimal("batting_sr", { precision: 8, scale: 4 })
+      .notNull()
+      .default("0"),
+
+    submittedAt: timestamp("submitted_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_cm_entries_round").on(table.roundId),
+    index("idx_cm_entries_user").on(table.userId),
+    unique("uq_cm_entries_round_user").on(table.roundId, table.userId),
+  ]
+);
+
+// Contest members — links users to contests; one entry shared across contests in a round
+export const cmContestMembers = pgTable(
+  "cm_contest_members",
+  {
+    contestId: uuid("contest_id")
+      .notNull()
+      .references(() => cmContests.id, { onDelete: "cascade" }),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id),
+    entryId: uuid("entry_id")
+      .notNull()
+      .references(() => cmEntries.id, { onDelete: "cascade" }),
+
+    rank: integer("rank"),
+    prizeWon: integer("prize_won").notNull().default(0),
+
+    joinedAt: timestamp("joined_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.contestId, table.userId] }),
+    index("idx_cm_cm_user").on(table.userId),
+    index("idx_cm_cm_rank").on(table.contestId, table.rank),
+  ]
+);
+
+// Per-league standings — cumulative NRR, wins, rank across all rounds in a league.
+// Separate from leagueMembers so we don't pollute the shared table with
+// format-specific stats.
+export const cmLeagueStandings = pgTable(
+  "cm_league_standings",
+  {
+    leagueId: uuid("league_id")
+      .notNull()
+      .references(() => leagues.id, { onDelete: "cascade" }),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id),
+    totalNrr: decimal("total_nrr", { precision: 10, scale: 4 })
+      .notNull()
+      .default("0"),
+    roundsPlayed: integer("rounds_played").notNull().default(0),
+    wins: integer("wins").notNull().default(0),
+    losses: integer("losses").notNull().default(0),
+    bestNrr: decimal("best_nrr", { precision: 8, scale: 4 }),
+    worstNrr: decimal("worst_nrr", { precision: 8, scale: 4 }),
+    avgNrr: decimal("avg_nrr", { precision: 8, scale: 4 }),
+    currentWinStreak: integer("current_win_streak").notNull().default(0),
+    bestWinStreak: integer("best_win_streak").notNull().default(0),
+    currentRank: integer("current_rank"),
+    prizeWon: integer("prize_won").notNull().default(0),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.leagueId, table.userId] }),
+    index("idx_cm_ls_user").on(table.userId),
+    index("idx_cm_ls_rank").on(table.leagueId, table.currentRank),
+  ]
+);
+
+// Chips — inventory per user per tournament
+export const cmChips = pgTable(
+  "cm_chips",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id),
+    tournamentId: uuid("tournament_id")
+      .notNull()
+      .references(() => tournaments.id),
+    chipType: text("chip_type").notNull(),
+
+    usedInRound: uuid("used_in_round").references(() => cmRounds.id),
+    usedAt: timestamp("used_at", { withTimezone: true }),
+
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    unique("uq_cm_chips_user_tournament_type").on(
+      table.userId,
+      table.tournamentId,
+      table.chipType
+    ),
+    index("idx_cm_chips_user").on(table.userId),
+  ]
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Relations
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const cmRoundsRelations = relations(cmRounds, ({ one, many }) => ({
+  league: one(leagues, {
+    fields: [cmRounds.leagueId],
+    references: [leagues.id],
+  }),
+  tournament: one(tournaments, {
+    fields: [cmRounds.tournamentId],
+    references: [tournaments.id],
+  }),
+  contests: many(cmContests),
+  entries: many(cmEntries),
+}));
+
+export const cmContestsRelations = relations(cmContests, ({ one, many }) => ({
+  round: one(cmRounds, {
+    fields: [cmContests.roundId],
+    references: [cmRounds.id],
+  }),
+  league: one(leagues, {
+    fields: [cmContests.leagueId],
+    references: [leagues.id],
+  }),
+  members: many(cmContestMembers),
+}));
+
+export const cmEntriesRelations = relations(cmEntries, ({ one, many }) => ({
+  round: one(cmRounds, {
+    fields: [cmEntries.roundId],
+    references: [cmRounds.id],
+  }),
+  user: one(users, {
+    fields: [cmEntries.userId],
+    references: [users.id],
+  }),
+  contestMemberships: many(cmContestMembers),
+}));
+
+export const cmContestMembersRelations = relations(
+  cmContestMembers,
+  ({ one }) => ({
+    contest: one(cmContests, {
+      fields: [cmContestMembers.contestId],
+      references: [cmContests.id],
+    }),
+    user: one(users, {
+      fields: [cmContestMembers.userId],
+      references: [users.id],
+    }),
+    entry: one(cmEntries, {
+      fields: [cmContestMembers.entryId],
+      references: [cmEntries.id],
+    }),
+  })
+);
+
+export const cmLeagueStandingsRelations = relations(
+  cmLeagueStandings,
+  ({ one }) => ({
+    league: one(leagues, {
+      fields: [cmLeagueStandings.leagueId],
+      references: [leagues.id],
+    }),
+    user: one(users, {
+      fields: [cmLeagueStandings.userId],
+      references: [users.id],
+    }),
+  })
+);
+
+export const cmChipsRelations = relations(cmChips, ({ one }) => ({
+  user: one(users, {
+    fields: [cmChips.userId],
+    references: [users.id],
+  }),
+  tournament: one(tournaments, {
+    fields: [cmChips.tournamentId],
+    references: [tournaments.id],
+  }),
+  usedRound: one(cmRounds, {
+    fields: [cmChips.usedInRound],
+    references: [cmRounds.id],
+  }),
+}));

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -23,3 +23,4 @@ export * from "./admin-config";
 export * from "./subscriptions";
 export * from "./cache";
 export * from "./chat";
+export * from "./cricket-manager";

--- a/packages/shared/src/types/contest.ts
+++ b/packages/shared/src/types/contest.ts
@@ -4,7 +4,8 @@ export type LeagueFormat =
   | "salary_cap"
   | "draft"
   | "auction"
-  | "prediction";
+  | "prediction"
+  | "cricket_manager";
 
 export type LeagueTemplate = "casual" | "competitive" | "pro" | "custom";
 export type LeagueStatus = "active" | "completed" | "archived";
@@ -68,6 +69,17 @@ export interface LeagueRules {
   // Playoffs
   playoffSize?: number;
   playoffFormat?: "knockout" | "round_robin";
+
+  // Cricket Manager format
+  cricketManager?: {
+    ballLimit?: number;              // default 120
+    minBowlersInSquad?: number;      // default 5
+    maxOversPerBowler?: number;      // default 4
+    prizeDistribution?: Array<{ rank: number; percent: number }>;
+    roundPrizeSplit?: { perRoundPct?: number; finalPct?: number };
+    prizePool?: number;              // guaranteed pool (Pop Coins)
+    entryFee?: number;               // one-time fee to join the league (PC)
+  };
 
   // Custom rules stored as JSON
   customRules?: Record<string, unknown>;

--- a/packages/shared/src/validators/league.ts
+++ b/packages/shared/src/validators/league.ts
@@ -2,7 +2,13 @@ import { z } from "zod";
 
 export const createLeagueSchema = z.object({
   name: z.string().min(1).max(100),
-  format: z.enum(["salary_cap", "draft", "auction", "prediction"]),
+  format: z.enum([
+    "salary_cap",
+    "draft",
+    "auction",
+    "prediction",
+    "cricket_manager",
+  ]),
   sport: z.enum(["cricket", "football", "kabaddi", "basketball"]).default("cricket"),
   tournament: z.string().min(1),
   season: z.string().optional(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,6 @@ overrides:
   react-dom: 19.1.0
   '@expo/metro-runtime': ~5.0.4
   react-native-worklets: 0.5.1
-  moti>react-native-worklets: 0.5.1
 
 importers:
 
@@ -25,6 +24,9 @@ importers:
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
+      concurrently:
+        specifier: ^9.2.1
+        version: 9.2.1
       pixelmatch:
         specifier: ^5.3.0
         version: 5.3.0
@@ -148,6 +150,9 @@ importers:
       react-native:
         specifier: 0.81.5
         version: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+      react-native-draggable-flatlist:
+        specifier: ^4.0.3
+        version: 4.0.3(@babel/core@7.29.0)(react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-reanimated@4.1.1(@babel/core@7.29.0)(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
       react-native-gesture-handler:
         specifier: ~2.28.0
         version: 2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -4753,6 +4758,11 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  concurrently@9.2.1:
+    resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   connect@3.7.0:
     resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
     engines: {node: '>= 0.10.0'}
@@ -7090,6 +7100,13 @@ packages:
   react-is@19.2.4:
     resolution: {integrity: sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==}
 
+  react-native-draggable-flatlist@4.0.3:
+    resolution: {integrity: sha512-2F4x5BFieWdGq9SetD2nSAR7s7oQCSgNllYgERRXXtNfSOuAGAVbDb/3H3lP0y5f7rEyNwabKorZAD/SyyNbDw==}
+    peerDependencies:
+      react-native: '>=0.64.0'
+      react-native-gesture-handler: '>=2.0.0'
+      react-native-reanimated: '>=2.8.0'
+
   react-native-gesture-handler@2.28.0:
     resolution: {integrity: sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==}
     peerDependencies:
@@ -7326,6 +7343,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -7757,6 +7777,10 @@ packages:
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
@@ -16782,6 +16806,15 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  concurrently@9.2.1:
+    dependencies:
+      chalk: 4.1.2
+      rxjs: 7.8.2
+      shell-quote: 1.8.3
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
+
   connect@3.7.0:
     dependencies:
       debug: 2.6.9
@@ -19573,6 +19606,16 @@ snapshots:
 
   react-is@19.2.4: {}
 
+  react-native-draggable-flatlist@4.0.3(@babel/core@7.29.0)(react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-reanimated@4.1.1(@babel/core@7.29.0)(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)):
+    dependencies:
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+      react-native-gesture-handler: 2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-reanimated: 4.1.1(@babel/core@7.29.0)(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
   react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@18.3.28)(react@19.1.0))(react@19.1.0):
     dependencies:
       '@egjs/hammerjs': 2.0.17
@@ -19975,6 +20018,10 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
 
   safe-buffer@5.2.1: {}
 
@@ -20713,6 +20760,8 @@ snapshots:
   toidentifier@1.0.1: {}
 
   tr46@0.0.3: {}
+
+  tree-kill@1.2.2: {}
 
   ts-interface-checker@0.1.13: {}
 

--- a/tests/unit/cm-engine.test.ts
+++ b/tests/unit/cm-engine.test.ts
@@ -1,0 +1,835 @@
+/**
+ * Unit Tests — Cricket Manager 120-ball engine
+ *
+ * Verifies the simulation pipeline against the worked example in
+ * /docs/CRICKET_MANAGER_DRAFT.md §18.
+ *
+ * Run: npx tsx tests/unit/cm-engine.test.ts
+ */
+
+import {
+  simulateEntry,
+  simulateBatting,
+  simulateBowling,
+  computeNrr,
+  oversToBalls,
+  ballsToOvers,
+  addOvers,
+  aggregatePlayerStats,
+  type AggregatedPlayerStats,
+  type EntryInput,
+  type RawMatchScore,
+} from "../../packages/api/src/services/cm-engine";
+
+// ── Test runner ─────────────────────────────────────────────────────────
+
+interface TestCase {
+  name: string;
+  fn: () => void;
+}
+const tests: TestCase[] = [];
+function test(name: string, fn: () => void) {
+  tests.push({ name, fn });
+}
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error(msg);
+}
+function assertEq(a: number, b: number, msg: string, tol = 0.01) {
+  if (Math.abs(a - b) > tol) throw new Error(`${msg}: expected ${b}, got ${a}`);
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function stats(partial: Partial<AggregatedPlayerStats> & { playerId: string }): AggregatedPlayerStats {
+  return {
+    playerId: partial.playerId,
+    role: partial.role ?? "batsman",
+    runs: partial.runs ?? 0,
+    ballsFaced: partial.ballsFaced ?? 0,
+    dismissed: partial.dismissed ?? false,
+    matchesBatted: partial.matchesBatted ?? 1,
+    overs: partial.overs ?? 0,
+    runsConceded: partial.runsConceded ?? 0,
+    wickets: partial.wickets ?? 0,
+    matchesBowled: partial.matchesBowled ?? 0,
+  };
+}
+
+// ── Overs arithmetic ────────────────────────────────────────────────────
+
+test("oversToBalls: 4.0 = 24 balls", () => {
+  assertEq(oversToBalls(4.0), 24, "4.0 overs");
+});
+test("oversToBalls: 4.3 = 27 balls (cricket notation)", () => {
+  assertEq(oversToBalls(4.3), 27, "4.3 overs");
+});
+test("ballsToOvers: 27 = 4.3 overs", () => {
+  assertEq(ballsToOvers(27), 4.3, "27 balls");
+});
+test("addOvers: 3.4 + 2.3 = 6.1", () => {
+  assertEq(addOvers(3.4, 2.3), 6.1, "add overs with carry");
+});
+
+// ── NRR formula ─────────────────────────────────────────────────────────
+
+test("computeNrr: baseline calculation", () => {
+  // Bat 190, Bowl 136 → (190/20) - (136/20) = 9.50 - 6.80 = 2.70
+  assertEq(computeNrr(190, 136), 2.7, "NRR baseline");
+});
+test("computeNrr: negative when bowling > batting", () => {
+  // Bat 100, Bowl 150 → (100/20) - (150/20) = 5.0 - 7.5 = -2.5
+  assertEq(computeNrr(100, 150), -2.5, "NRR negative");
+});
+
+// ── Worked example from §18 ─────────────────────────────────────────────
+
+test("worked example: Kohli/Gill/Pant/Pandya/... → NRR +2.70", () => {
+  // Squad (from doc §18.1)
+  const squad = [
+    { id: "kohli", runs: 45, balls: 30, out: true, overs: 0, conceded: 0, wickets: 0 },
+    { id: "gill", runs: 72, balls: 48, out: true, overs: 0, conceded: 0, wickets: 0 },
+    { id: "pant", runs: 28, balls: 15, out: false, overs: 0, conceded: 0, wickets: 0 },
+    { id: "pandya", runs: 45, balls: 27, out: true, overs: 5.0, conceded: 44, wickets: 1 },
+    { id: "jadeja", runs: 22, balls: 14, out: true, overs: 4.0, conceded: 24, wickets: 2 },
+    { id: "ishan", runs: 8, balls: 6, out: true, overs: 0, conceded: 0, wickets: 0 },
+    { id: "bumrah", runs: 0, balls: 0, out: false, overs: 8.0, conceded: 40, wickets: 5 },
+    { id: "shami", runs: 0, balls: 0, out: false, overs: 4.0, conceded: 32, wickets: 1 },
+    { id: "chahal", runs: 0, balls: 0, out: false, overs: 4.0, conceded: 36, wickets: 1 },
+    { id: "rashid", runs: 0, balls: 0, out: false, overs: 4.0, conceded: 24, wickets: 2 },
+    { id: "chahar", runs: 0, balls: 0, out: false, overs: 3.0, conceded: 28, wickets: 1 },
+  ];
+
+  const statsMap = new Map<string, AggregatedPlayerStats>();
+  for (const p of squad) {
+    statsMap.set(
+      p.id,
+      stats({
+        playerId: p.id,
+        runs: p.runs,
+        ballsFaced: p.balls,
+        dismissed: p.out,
+        overs: p.overs,
+        runsConceded: p.conceded,
+        wickets: p.wickets,
+      })
+    );
+  }
+
+  const entry: EntryInput = {
+    players: squad.map((p) => ({ playerId: p.id })),
+    battingOrder: [
+      { position: 1, playerId: "kohli" },
+      { position: 2, playerId: "gill" },
+      { position: 3, playerId: "pant" },
+      { position: 4, playerId: "pandya" },
+      { position: 5, playerId: "jadeja" },
+      { position: 6, playerId: "ishan" },
+      { position: 7, playerId: "bumrah" },
+      { position: 8, playerId: "shami" },
+      { position: 9, playerId: "chahal" },
+      { position: 10, playerId: "rashid" },
+      { position: 11, playerId: "chahar" },
+    ],
+    bowlingPriority: [
+      { priority: 1, playerId: "bumrah" },
+      { priority: 2, playerId: "shami" },
+      { priority: 3, playerId: "chahal" },
+      { priority: 4, playerId: "rashid" },
+      { priority: 5, playerId: "jadeja" },
+      { priority: 6, playerId: "pandya" },
+      { priority: 7, playerId: "chahar" },
+    ],
+  };
+
+  const result = simulateEntry(entry, statsMap);
+
+  // Batting: Kohli 45(30) + Gill 72(48) + Pant 28(15) + Pandya 45(27) = 190 in 120 balls
+  assertEq(result.batting.total, 190, "batting total");
+  assertEq(result.batting.ballsUsed, 120, "batting balls used");
+  assertEq(result.batting.wickets, 3, "batting wickets");
+
+  // Bowling: Bumrah 4ov/20r (capped from 8ov/40r = half) + Shami 4ov/32r + Chahal 4ov/36r
+  //        + Rashid 4ov/24r + Jadeja 4ov/24r = 136 conceded
+  assertEq(result.bowling.total, 136, "bowling total");
+  assertEq(result.bowling.ballsBowled, 120, "bowling balls bowled");
+
+  // NRR = (190/20) - (136/20) = 9.50 - 6.80 = +2.70
+  assertEq(result.nrr, 2.7, "nrr");
+
+  // Batting SR = (190/120) * 100 = 158.33
+  assertEq(result.battingSr, 158.3333, "batting sr", 0.01);
+
+  assert(result.win, "batting should beat bowling");
+});
+
+// ── All-out scenario ────────────────────────────────────────────────────
+
+test("all-out batting: denominator stays at 20 (ICC rule)", () => {
+  // 10 batters each score 5 runs off 6 balls and get out; 11th can't bat.
+  // Total: 50 runs in 60 balls, 10 wickets → all out
+  const statsMap = new Map<string, AggregatedPlayerStats>();
+  for (let i = 1; i <= 11; i++) {
+    statsMap.set(
+      `p${i}`,
+      stats({
+        playerId: `p${i}`,
+        runs: i <= 10 ? 5 : 0,
+        ballsFaced: i <= 10 ? 6 : 0,
+        dismissed: i <= 10,
+      })
+    );
+  }
+  // One bowler, uses full 4 overs, concedes 40
+  statsMap.set(
+    "bowl1",
+    stats({
+      playerId: "bowl1",
+      role: "bowler",
+      overs: 4.0,
+      runsConceded: 40,
+      wickets: 0,
+    })
+  );
+
+  const entry: EntryInput = {
+    players: [...Array(11)].map((_, i) => ({ playerId: `p${i + 1}` })),
+    battingOrder: [...Array(11)].map((_, i) => ({
+      position: i + 1,
+      playerId: `p${i + 1}`,
+    })),
+    bowlingPriority: [{ priority: 1, playerId: "bowl1" }],
+  };
+
+  const result = simulateEntry(entry, statsMap);
+
+  assertEq(result.batting.total, 50, "all-out total");
+  assert(result.batting.allOut, "should be all out");
+  assertEq(result.batting.wickets, 10, "10 wickets");
+
+  // NRR = (50/20) - (40/20) = 2.5 - 2.0 = 0.5
+  // Denominator stays 20 even though only 60 balls used — ICC rule
+  assertEq(result.nrr, 0.5, "all-out NRR uses full 20 overs");
+});
+
+// ── Bowling lethality (wickets = 10 freezes total) ──────────────────────
+
+test("bowling freezes at 10 wickets", () => {
+  const statsMap = new Map<string, AggregatedPlayerStats>();
+  // Two bowlers, each with 4 overs and 5 wickets
+  statsMap.set(
+    "b1",
+    stats({
+      playerId: "b1",
+      role: "bowler",
+      overs: 4.0,
+      runsConceded: 20,
+      wickets: 5,
+    })
+  );
+  statsMap.set(
+    "b2",
+    stats({
+      playerId: "b2",
+      role: "bowler",
+      overs: 4.0,
+      runsConceded: 30,
+      wickets: 5,
+    })
+  );
+  // Filler bowler — should NOT contribute because 10 wickets already
+  statsMap.set(
+    "b3",
+    stats({
+      playerId: "b3",
+      role: "bowler",
+      overs: 4.0,
+      runsConceded: 50,
+      wickets: 1,
+    })
+  );
+
+  // Dummy batting to fill the entry
+  for (let i = 1; i <= 11; i++) {
+    if (!statsMap.has(`b${i}`)) {
+      statsMap.set(`bat${i}`, stats({ playerId: `bat${i}`, runs: 10, ballsFaced: 10 }));
+    }
+  }
+
+  const entry: EntryInput = {
+    players: [
+      { playerId: "b1" },
+      { playerId: "b2" },
+      { playerId: "b3" },
+      ...[...Array(8)].map((_, i) => ({ playerId: `bat${i + 1}` })),
+    ],
+    battingOrder: [
+      { position: 1, playerId: "b1" },
+      { position: 2, playerId: "b2" },
+      { position: 3, playerId: "b3" },
+      ...[...Array(8)].map((_, i) => ({ position: i + 4, playerId: `bat${i + 1}` })),
+    ],
+    bowlingPriority: [
+      { priority: 1, playerId: "b1" },
+      { priority: 2, playerId: "b2" },
+      { priority: 3, playerId: "b3" },
+    ],
+  };
+
+  const result = simulateBowling(entry, statsMap, {
+    ballLimit: 120,
+    maxOversPerBowler: 4,
+  });
+
+  // b1: 4 overs / 20 runs / 5 wickets (cumulative 5, under limit)
+  // b2: 4 overs / 30 runs / 5 wickets (cumulative 10, limit reached)
+  // b3: frozen — 0 contribution
+  assertEq(result.total, 50, "bowling total freezes at 50");
+  assertEq(result.wickets, 10, "wickets capped at 10");
+});
+
+// ── Aggregation across multiple matches ─────────────────────────────────
+
+test("aggregatePlayerStats: sums runs and overs correctly", () => {
+  const raw: RawMatchScore[] = [
+    {
+      playerId: "kohli",
+      role: "batsman",
+      runs: 45,
+      ballsFaced: 30,
+      isDismissed: true,
+      overs: 0,
+      runsConceded: 0,
+      wickets: 0,
+    },
+    {
+      playerId: "kohli",
+      role: "batsman",
+      runs: 22,
+      ballsFaced: 18,
+      isDismissed: false,
+      overs: 0,
+      runsConceded: 0,
+      wickets: 0,
+    },
+    {
+      playerId: "bumrah",
+      role: "bowler",
+      runs: 0,
+      ballsFaced: 0,
+      isDismissed: false,
+      overs: 4.0,
+      runsConceded: 20,
+      wickets: 2,
+    },
+    {
+      playerId: "bumrah",
+      role: "bowler",
+      runs: 0,
+      ballsFaced: 0,
+      isDismissed: false,
+      overs: 4.0,
+      runsConceded: 20,
+      wickets: 3,
+    },
+  ];
+
+  const agg = aggregatePlayerStats(raw);
+
+  const kohli = agg.get("kohli")!;
+  assertEq(kohli.runs, 67, "kohli runs");
+  assertEq(kohli.ballsFaced, 48, "kohli balls");
+  assert(kohli.dismissed, "kohli dismissed in one match");
+  assertEq(kohli.matchesBatted, 2, "kohli matches batted");
+
+  const bumrah = agg.get("bumrah")!;
+  assertEq(bumrah.overs, 8.0, "bumrah overs (4+4)");
+  assertEq(bumrah.runsConceded, 40, "bumrah conceded");
+  assertEq(bumrah.wickets, 5, "bumrah wickets");
+});
+
+// ── Partial innings (ball budget exhausted mid-batter) ──────────────────
+
+test("partial innings: last batter scales runs by SR", () => {
+  const statsMap = new Map<string, AggregatedPlayerStats>();
+  // #1 uses 118 balls scoring 200
+  statsMap.set(
+    "a",
+    stats({ playerId: "a", runs: 200, ballsFaced: 118, dismissed: false })
+  );
+  // #2 has SR 150 (30 runs off 20 balls) — only 2 balls remaining
+  // Expected: 2 * 1.5 = 3 runs credited
+  statsMap.set(
+    "b",
+    stats({ playerId: "b", runs: 30, ballsFaced: 20, dismissed: true })
+  );
+
+  const entry: EntryInput = {
+    players: [{ playerId: "a" }, { playerId: "b" }],
+    battingOrder: [
+      { position: 1, playerId: "a" },
+      { position: 2, playerId: "b" },
+    ],
+    bowlingPriority: [],
+  };
+
+  const result = simulateBatting(entry, statsMap, {
+    ballLimit: 120,
+    maxOversPerBowler: 4,
+  });
+
+  assertEq(result.total, 203, "200 + 3");
+  assertEq(result.ballsUsed, 120, "full budget used");
+  // Partial batter is NOT dismissed (innings cut off by ball budget)
+  assertEq(result.wickets, 0, "no dismissal on partial");
+});
+
+// ── Toss: bat_first vs bowl_first ───────────────────────────────────────
+
+test("toss bowl_first: batters stop when chase target reached (rate-based denominators)", () => {
+  // Squad: bowlers keep opposition to 136 (same as worked example).
+  // Chasing 137, Kohli 45(30) + Gill 72(48) = 117 in 78 balls.
+  // Pant comes in needing 20 more at SR 28/15 ≈ 1.867 → ~11 balls.
+  // Final: 137 runs in 89 balls, chaseComplete = true.
+  //
+  // Under the new bowl_first semantics, NRR denominators are actual overs:
+  //   batting = 89/6 ≈ 14.833 ov, bowling = 120/6 = 20.0 ov
+  //   NRR = 137/14.833 - 136/20 = 9.2360 - 6.80 ≈ +2.44
+  // (vs the old 20/20 calculation which gave a broken +0.05)
+  const squad = [
+    { id: "kohli", runs: 45, balls: 30, out: true, overs: 0, conceded: 0, wickets: 0 },
+    { id: "gill", runs: 72, balls: 48, out: true, overs: 0, conceded: 0, wickets: 0 },
+    { id: "pant", runs: 28, balls: 15, out: false, overs: 0, conceded: 0, wickets: 0 },
+    { id: "pandya", runs: 45, balls: 27, out: true, overs: 5.0, conceded: 44, wickets: 1 },
+    { id: "jadeja", runs: 22, balls: 14, out: true, overs: 4.0, conceded: 24, wickets: 2 },
+    { id: "ishan", runs: 8, balls: 6, out: true, overs: 0, conceded: 0, wickets: 0 },
+    { id: "bumrah", runs: 0, balls: 0, out: false, overs: 8.0, conceded: 40, wickets: 5 },
+    { id: "shami", runs: 0, balls: 0, out: false, overs: 4.0, conceded: 32, wickets: 1 },
+    { id: "chahal", runs: 0, balls: 0, out: false, overs: 4.0, conceded: 36, wickets: 1 },
+    { id: "rashid", runs: 0, balls: 0, out: false, overs: 4.0, conceded: 24, wickets: 2 },
+    { id: "chahar", runs: 0, balls: 0, out: false, overs: 3.0, conceded: 28, wickets: 1 },
+  ];
+  const statsMap = new Map<string, AggregatedPlayerStats>();
+  for (const p of squad) {
+    statsMap.set(p.id, stats({
+      playerId: p.id, runs: p.runs, ballsFaced: p.balls,
+      dismissed: p.out, overs: p.overs, runsConceded: p.conceded, wickets: p.wickets,
+    }));
+  }
+
+  const entry: EntryInput = {
+    players: squad.map((p) => ({ playerId: p.id })),
+    battingOrder: [
+      { position: 1, playerId: "kohli" },
+      { position: 2, playerId: "gill" },
+      { position: 3, playerId: "pant" },
+      { position: 4, playerId: "pandya" },
+      { position: 5, playerId: "jadeja" },
+      { position: 6, playerId: "ishan" },
+      { position: 7, playerId: "bumrah" },
+      { position: 8, playerId: "shami" },
+      { position: 9, playerId: "chahal" },
+      { position: 10, playerId: "rashid" },
+      { position: 11, playerId: "chahar" },
+    ],
+    bowlingPriority: [
+      { priority: 1, playerId: "bumrah" },
+      { priority: 2, playerId: "shami" },
+      { priority: 3, playerId: "chahal" },
+      { priority: 4, playerId: "rashid" },
+      { priority: 5, playerId: "jadeja" },
+    ],
+  };
+
+  const result = simulateEntry(entry, statsMap, undefined, "bowl_first");
+
+  // Bowling total still 136 (computed first, same as bat_first)
+  assertEq(result.bowling.total, 136, "bowl first: bowling total");
+
+  // Batting stopped at target = 137 (not the full 190)
+  assertEq(result.batting.total, 137, "bowl first: batting capped at target");
+  assert(result.batting.chaseComplete, "chase marked complete");
+
+  // Rate-based: 137/14.833 - 136/20 ≈ 2.436
+  assertEq(result.nrr, 2.436, "bowl first NRR (rate-based)", 0.01);
+  // Chase rewards bowl_first over bat_first (+2.70) in this scenario
+  assert(result.nrr < 2.7, "bowl first should be slightly below bat first here");
+  assert(result.nrr > 2.0, "but still positive — chase was efficient");
+});
+
+test("toss bowl_first: high bowling total means batters cannot chase, innings runs full", () => {
+  // Same batting squad, but bowlers leak: bowling total = 250.
+  // Batters can only accumulate 190 in 120 balls, nowhere near 251.
+  // Batting should NOT be capped by chase (no chaseComplete).
+  const squad = [
+    { id: "kohli", runs: 45, balls: 30, out: true },
+    { id: "gill", runs: 72, balls: 48, out: true },
+    { id: "pant", runs: 28, balls: 15, out: false },
+    { id: "pandya", runs: 45, balls: 27, out: true },
+  ];
+  const statsMap = new Map<string, AggregatedPlayerStats>();
+  for (const p of squad) {
+    statsMap.set(p.id, stats({
+      playerId: p.id, runs: p.runs, ballsFaced: p.balls, dismissed: p.out,
+    }));
+  }
+  // One very-expensive bowler so bowlTotal is high
+  statsMap.set("gen", stats({
+    playerId: "gen", role: "bowler",
+    overs: 20.0, runsConceded: 250, wickets: 0,
+  }));
+
+  const entry: EntryInput = {
+    players: [...squad.map((p) => ({ playerId: p.id })), { playerId: "gen" }],
+    battingOrder: [
+      { position: 1, playerId: "kohli" },
+      { position: 2, playerId: "gill" },
+      { position: 3, playerId: "pant" },
+      { position: 4, playerId: "pandya" },
+      { position: 5, playerId: "gen" },
+    ],
+    bowlingPriority: [{ priority: 1, playerId: "gen" }],
+  };
+
+  const result = simulateEntry(entry, statsMap, undefined, "bowl_first");
+
+  assertEq(result.bowling.total, 50, "capped to 4 overs → 250 × (24/120) = 50");
+  // Hmm — bowler capped at 4 overs so actual bowling total is 50, not 250.
+  // So target = 51. Kohli alone (45) isn't enough, Gill (72) overshoots.
+  // Kohli 45 + Gill 6 (partial chase) = 51.
+  assertEq(result.batting.total, 51, "chase stops at target");
+  assert(result.batting.chaseComplete, "chase completed");
+});
+
+test("toss bat_first: same squad batting runs full 120 balls regardless of bowl total", () => {
+  const squad = [
+    { id: "kohli", runs: 45, balls: 30, out: true, overs: 0, conceded: 0, wickets: 0 },
+    { id: "gill", runs: 72, balls: 48, out: true, overs: 0, conceded: 0, wickets: 0 },
+    { id: "pant", runs: 28, balls: 15, out: false, overs: 0, conceded: 0, wickets: 0 },
+    { id: "pandya", runs: 45, balls: 27, out: true, overs: 5.0, conceded: 44, wickets: 1 },
+    { id: "jadeja", runs: 22, balls: 14, out: true, overs: 4.0, conceded: 24, wickets: 2 },
+    { id: "ishan", runs: 8, balls: 6, out: true, overs: 0, conceded: 0, wickets: 0 },
+    { id: "bumrah", runs: 0, balls: 0, out: false, overs: 8.0, conceded: 40, wickets: 5 },
+    { id: "shami", runs: 0, balls: 0, out: false, overs: 4.0, conceded: 32, wickets: 1 },
+    { id: "chahal", runs: 0, balls: 0, out: false, overs: 4.0, conceded: 36, wickets: 1 },
+    { id: "rashid", runs: 0, balls: 0, out: false, overs: 4.0, conceded: 24, wickets: 2 },
+    { id: "chahar", runs: 0, balls: 0, out: false, overs: 3.0, conceded: 28, wickets: 1 },
+  ];
+  const statsMap = new Map<string, AggregatedPlayerStats>();
+  for (const p of squad) {
+    statsMap.set(p.id, stats({
+      playerId: p.id, runs: p.runs, ballsFaced: p.balls,
+      dismissed: p.out, overs: p.overs, runsConceded: p.conceded, wickets: p.wickets,
+    }));
+  }
+
+  const entry: EntryInput = {
+    players: squad.map((p) => ({ playerId: p.id })),
+    battingOrder: [
+      { position: 1, playerId: "kohli" },
+      { position: 2, playerId: "gill" },
+      { position: 3, playerId: "pant" },
+      { position: 4, playerId: "pandya" },
+      { position: 5, playerId: "jadeja" },
+      { position: 6, playerId: "ishan" },
+      { position: 7, playerId: "bumrah" },
+      { position: 8, playerId: "shami" },
+      { position: 9, playerId: "chahal" },
+      { position: 10, playerId: "rashid" },
+      { position: 11, playerId: "chahar" },
+    ],
+    bowlingPriority: [
+      { priority: 1, playerId: "bumrah" },
+      { priority: 2, playerId: "shami" },
+      { priority: 3, playerId: "chahal" },
+      { priority: 4, playerId: "rashid" },
+      { priority: 5, playerId: "jadeja" },
+    ],
+  };
+
+  // Default toss is bat_first
+  const result = simulateEntry(entry, statsMap);
+  assertEq(result.batting.total, 190, "bat first: full innings");
+  assertEq(result.bowling.total, 136, "bat first: bowling total");
+  assertEq(result.nrr, 2.7, "bat first NRR");
+  assert(!result.batting.chaseComplete, "no chase in bat_first");
+});
+
+// ── Phantom-fill & new toss semantics (Appendix A fix) ────────────────
+
+test("phantom-fill: 5 real 4-over bowlers pay zero penalty (honest baseline)", () => {
+  // Honest attack: 5 × 4 overs = 120 balls bowled, 150 runs conceded.
+  // No ghost bowlers → phantom fill must not trigger.
+  const statsMap = new Map<string, AggregatedPlayerStats>();
+  for (let i = 1; i <= 5; i++) {
+    statsMap.set(
+      `b${i}`,
+      stats({
+        playerId: `b${i}`,
+        role: "bowler",
+        overs: 4.0,
+        runsConceded: 30,
+        wickets: 1,
+      })
+    );
+  }
+  // Dummy batting so batting total doesn't interfere
+  for (let i = 1; i <= 11; i++) {
+    statsMap.set(`bat${i}`, stats({ playerId: `bat${i}`, runs: 20, ballsFaced: 12 }));
+  }
+
+  const entry: EntryInput = {
+    players: [
+      ...[...Array(5)].map((_, i) => ({ playerId: `b${i + 1}` })),
+      ...[...Array(11)].map((_, i) => ({ playerId: `bat${i + 1}` })),
+    ],
+    battingOrder: [...Array(11)].map((_, i) => ({
+      position: i + 1,
+      playerId: `bat${i + 1}`,
+    })),
+    bowlingPriority: [...Array(5)].map((_, i) => ({
+      priority: i + 1,
+      playerId: `b${i + 1}`,
+    })),
+  };
+
+  const result = simulateEntry(
+    entry,
+    statsMap,
+    { ballLimit: 120, maxOversPerBowler: 4, phantomFillER: 9.0 },
+    "bat_first"
+  );
+
+  assertEq(result.bowling.total, 150, "bowling total unchanged");
+  assertEq(result.bowling.ballsBowled, 120, "120 balls bowled (full)");
+  assert(!result.bowling.phantomApplied, "phantom NOT applied — no gap");
+  assertEq(result.bowling.phantomRuns, 0, "zero phantom runs");
+});
+
+test("phantom-fill: ghost bowler cheater gets charged at round-avg ER (bat_first)", () => {
+  // Cheater: 3 real bowlers (72 balls, 82 runs) + 2 ghost bowlers (0 overs each).
+  // Round-avg ER = 9.5 (high-scoring round). The 48-ball gap should be filled
+  // with round(8.0 × 9.5) = 76 phantom runs → total = 82 + 76 = 158.
+  const statsMap = new Map<string, AggregatedPlayerStats>();
+  statsMap.set("real1", stats({ playerId: "real1", role: "bowler", overs: 4.0, runsConceded: 28, wickets: 2 }));
+  statsMap.set("real2", stats({ playerId: "real2", role: "bowler", overs: 4.0, runsConceded: 35, wickets: 1 }));
+  statsMap.set("real3", stats({ playerId: "real3", role: "bowler", overs: 4.0, runsConceded: 19, wickets: 2 }));
+  // Ghost bowlers — 0 real overs
+  statsMap.set("ghost1", stats({ playerId: "ghost1", role: "batsman", overs: 0, runsConceded: 0, wickets: 0 }));
+  statsMap.set("ghost2", stats({ playerId: "ghost2", role: "batsman", overs: 0, runsConceded: 0, wickets: 0 }));
+  // Dummy batters
+  for (let i = 1; i <= 11; i++) {
+    statsMap.set(`bat${i}`, stats({ playerId: `bat${i}`, runs: 18, ballsFaced: 10 }));
+  }
+
+  const entry: EntryInput = {
+    players: [
+      { playerId: "real1" },
+      { playerId: "real2" },
+      { playerId: "real3" },
+      { playerId: "ghost1" },
+      { playerId: "ghost2" },
+      ...[...Array(11)].map((_, i) => ({ playerId: `bat${i + 1}` })),
+    ],
+    battingOrder: [...Array(11)].map((_, i) => ({
+      position: i + 1,
+      playerId: `bat${i + 1}`,
+    })),
+    bowlingPriority: [
+      { priority: 1, playerId: "real1" },
+      { priority: 2, playerId: "real2" },
+      { priority: 3, playerId: "real3" },
+      { priority: 4, playerId: "ghost1" },
+      { priority: 5, playerId: "ghost2" },
+    ],
+  };
+
+  const result = simulateEntry(
+    entry,
+    statsMap,
+    { ballLimit: 120, maxOversPerBowler: 4, phantomFillER: 9.5 },
+    "bat_first"
+  );
+
+  // Real: 4+4+4 = 12 overs = 72 balls, runs = 28+35+19 = 82
+  // Phantom: 48 balls × 9.5/6 = 76 runs
+  assertEq(result.bowling.total, 82 + 76, "real + phantom runs");
+  assertEq(result.bowling.ballsBowled, 120, "phantom fills to full budget");
+  assert(result.bowling.phantomApplied, "phantom fill applied");
+  assertEq(result.bowling.phantomBalls, 48, "48 phantom balls");
+  assertEq(result.bowling.phantomRuns, 76, "76 phantom runs");
+});
+
+test("phantom-fill: NOT triggered when bowling-out (wickets >= 10)", () => {
+  // 5 bowlers take 2 wickets each = 10 wickets, only 60 balls bowled.
+  // Lethality stop should fire; phantom fill must NOT kick in because the
+  // short innings was earned by bowling the opposition out.
+  const statsMap = new Map<string, AggregatedPlayerStats>();
+  for (let i = 1; i <= 5; i++) {
+    statsMap.set(
+      `b${i}`,
+      stats({
+        playerId: `b${i}`,
+        role: "bowler",
+        overs: 2.0,
+        runsConceded: 10,
+        wickets: 2,
+      })
+    );
+  }
+  for (let i = 1; i <= 11; i++) {
+    statsMap.set(`bat${i}`, stats({ playerId: `bat${i}`, runs: 20, ballsFaced: 12 }));
+  }
+
+  const entry: EntryInput = {
+    players: [
+      ...[...Array(5)].map((_, i) => ({ playerId: `b${i + 1}` })),
+      ...[...Array(11)].map((_, i) => ({ playerId: `bat${i + 1}` })),
+    ],
+    battingOrder: [...Array(11)].map((_, i) => ({
+      position: i + 1,
+      playerId: `bat${i + 1}`,
+    })),
+    bowlingPriority: [...Array(5)].map((_, i) => ({
+      priority: i + 1,
+      playerId: `b${i + 1}`,
+    })),
+  };
+
+  const result = simulateEntry(
+    entry,
+    statsMap,
+    { ballLimit: 120, maxOversPerBowler: 4, phantomFillER: 9.0 },
+    "bat_first"
+  );
+
+  assertEq(result.bowling.wickets, 10, "10 wickets (bowled out)");
+  assertEq(result.bowling.total, 50, "50 runs — no phantom fill");
+  assert(!result.bowling.phantomApplied, "phantom NOT applied after lethality");
+});
+
+test("bowl_first fast chase: rate-based denominators reward efficient chase", () => {
+  // Low bowling total (5 bowlers, 100 runs in 120 balls) + efficient chase
+  // (target 101 chased in 60 balls) should beat bat_first in this scenario.
+  const statsMap = new Map<string, AggregatedPlayerStats>();
+  // 5 bowlers, each 4-0-20-0 → 100 runs total in 120 balls
+  for (let i = 1; i <= 5; i++) {
+    statsMap.set(`b${i}`, stats({
+      playerId: `b${i}`, role: "bowler",
+      overs: 4.0, runsConceded: 20, wickets: 0,
+    }));
+  }
+  // Top order: Kohli 60(30) SR 200, Rohit 50(30) SR 166
+  statsMap.set("kohli", stats({ playerId: "kohli", runs: 60, ballsFaced: 30, dismissed: true }));
+  statsMap.set("rohit", stats({ playerId: "rohit", runs: 50, ballsFaced: 30, dismissed: true }));
+  for (let i = 3; i <= 11; i++) {
+    statsMap.set(`bat${i}`, stats({ playerId: `bat${i}`, runs: 15, ballsFaced: 12 }));
+  }
+
+  const entry: EntryInput = {
+    players: [
+      { playerId: "kohli" }, { playerId: "rohit" },
+      ...[...Array(9)].map((_, i) => ({ playerId: `bat${i + 3}` })),
+      ...[...Array(5)].map((_, i) => ({ playerId: `b${i + 1}` })),
+    ],
+    battingOrder: [
+      { position: 1, playerId: "kohli" },
+      { position: 2, playerId: "rohit" },
+      ...[...Array(9)].map((_, i) => ({ position: i + 3, playerId: `bat${i + 3}` })),
+    ],
+    bowlingPriority: [...Array(5)].map((_, i) => ({
+      priority: i + 1, playerId: `b${i + 1}`,
+    })),
+  };
+
+  // bat_first: batting freerolls, bowling freerolls
+  const batFirst = simulateEntry(
+    entry, statsMap,
+    { ballLimit: 120, maxOversPerBowler: 4, phantomFillER: 9.0 },
+    "bat_first"
+  );
+  // bowl_first: chase target 101 — Kohli 60(30) + Rohit 41(25) to hit target
+  const bowlFirst = simulateEntry(
+    entry, statsMap,
+    { ballLimit: 120, maxOversPerBowler: 4, phantomFillER: 9.0 },
+    "bowl_first"
+  );
+
+  assertEq(bowlFirst.bowling.total, 100, "bowling total 100 in bowl_first");
+  assert(bowlFirst.batting.chaseComplete, "chase completed");
+  // bowl_first should beat bat_first because chase was ~55 balls for 101 runs
+  // (rate ~11 rpo) while bat_first's full-20-over rate is much lower
+  assert(
+    bowlFirst.nrr > batFirst.nrr,
+    `bowl_first (${bowlFirst.nrr}) should beat bat_first (${batFirst.nrr}) on fast chase`
+  );
+});
+
+test("bowl_first failed chase: falls back to 20-over batting denominator", () => {
+  // Bowling leaks 160 runs. Batting SR is low (only scores 120 off 120 balls).
+  // Chase fails → batting denominator should be 20, not actual balls.
+  const statsMap = new Map<string, AggregatedPlayerStats>();
+  // Expensive bowlers
+  for (let i = 1; i <= 5; i++) {
+    statsMap.set(`b${i}`, stats({
+      playerId: `b${i}`, role: "bowler",
+      overs: 4.0, runsConceded: 32, wickets: 0,
+    }));
+  }
+  // Pedestrian batters: 11 × 12 runs in 12 balls = 132 runs in 132 balls
+  // (SR 100, no one special — caps at 120 balls giving ~120 runs)
+  for (let i = 1; i <= 11; i++) {
+    statsMap.set(`bat${i}`, stats({
+      playerId: `bat${i}`, runs: 12, ballsFaced: 12, dismissed: false,
+    }));
+  }
+
+  const entry: EntryInput = {
+    players: [
+      ...[...Array(11)].map((_, i) => ({ playerId: `bat${i + 1}` })),
+      ...[...Array(5)].map((_, i) => ({ playerId: `b${i + 1}` })),
+    ],
+    battingOrder: [...Array(11)].map((_, i) => ({
+      position: i + 1, playerId: `bat${i + 1}`,
+    })),
+    bowlingPriority: [...Array(5)].map((_, i) => ({
+      priority: i + 1, playerId: `b${i + 1}`,
+    })),
+  };
+
+  const result = simulateEntry(
+    entry, statsMap,
+    { ballLimit: 120, maxOversPerBowler: 4, phantomFillER: 9.0 },
+    "bowl_first"
+  );
+
+  assertEq(result.bowling.total, 160, "bowling total 160");
+  assert(!result.batting.chaseComplete, "chase failed");
+  assertEq(result.batting.ballsUsed, 120, "full 120 balls used trying to chase");
+  // Failed chase → batting denominator back to 20 (ICC full-allocation penalty).
+  // NRR = 120/20 - 160/20 = 6.0 - 8.0 = -2.0
+  assertEq(result.nrr, -2.0, "failed chase falls back to 20-over denominator");
+});
+
+// ── Run ─────────────────────────────────────────────────────────────────
+
+let passed = 0;
+let failed = 0;
+const failures: string[] = [];
+
+for (const t of tests) {
+  try {
+    t.fn();
+    passed++;
+    console.log(`  ✓ ${t.name}`);
+  } catch (err: unknown) {
+    failed++;
+    const msg = err instanceof Error ? err.message : String(err);
+    failures.push(`  ✗ ${t.name}\n    ${msg}`);
+    console.log(`  ✗ ${t.name}\n    ${msg}`);
+  }
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- New 120-ball **Cricket Manager** fantasy format: admin composes rounds, members pick 11 players with batting order + bowling priority, compete via NRR
- **Engine loophole fixes** (Appendix A in docs): phantom-fill closes the "ghost bowler" exploit; `bowl_first` toss now uses rate-based denominators so the toss mechanic is real
- Canonical `applyMatchPhaseChange` helper: all phase transitions (admin, background refresh, score updater) now fire the same side-effects consistently

## What's new
- **DB** — migrations 0020/0021/0022 create `cm_rounds`, `cm_contests`, `cm_entries`, `cm_contest_members`, `cm_league_standings`, `cm_chips` + streak/toss columns. All idempotent.
- **API** — `cm-engine.ts` (pure 120-ball sim), `cm-service.ts` (compose/submit/settle), `cm-guru.ts` (AI analysis), new tRPC router at `cricketManager.*`
- **Admin portal** — new `/admin/leagues` pages to create CM leagues, compose rounds, and trigger settlement
- **Mobile** — round hub, live scorecards, leaderboard, strategy reveal, dual-bar race, NRR explainer
- **Wallet fix** — `cm_contest_win` now renders as a green credit (was showing as red debit). Signup bonus txn now renders as "sign on bonus" instead of raw "achievement"

## Engine changes
- `simulateBowling` takes an optional `applyPhantomFill` flag. When `bat_first` and the real innings ends with unused balls + fewer than 10 wickets, the gap is filled with notional runs at `config.phantomFillER` (computed from the round's own average ER)
- `computeNrr` accepts dynamic `battingOvers` / `bowlingOvers` defaulting to 20
- `simulateEntry` branches on toss:
  - `bat_first` — phantom-fill + 20/20 denominators
  - `bowl_first` — real bowling + actual-overs denominators for batting (on successful chase) and bowling; failed chase falls back to 20-over batting penalty
- `cm-service.ts` computes round-average ER from real match data and threads it into `RoundConfig` on every sim call

## Tests
- 19 unit tests in [tests/unit/cm-engine.test.ts](tests/unit/cm-engine.test.ts), including 5 new regression tests for the loophole fixes:
  - `phantom-fill: 5 real 4-over bowlers pay zero penalty (honest baseline)`
  - `phantom-fill: ghost bowler cheater gets charged at round-avg ER`
  - `phantom-fill: NOT triggered when bowling-out (wickets >= 10)`
  - `bowl_first fast chase: rate-based denominators reward efficient chase`
  - `bowl_first failed chase: falls back to 20-over batting denominator`
- All 19 passing

## Test plan
- [ ] Run migrations 0020/0021/0022 against Cloud SQL (take a snapshot first)
- [ ] Deploy API via `./scripts/deploy-api.sh`, confirm health check
- [ ] Create a CM league via admin portal, compose a round with upcoming matches
- [ ] Submit an entry from mobile, verify round hub loads with live scorecards
- [ ] After matches complete, verify settlement pays out PC correctly and wallet renders `cm_contest_win` as green credit
- [ ] Verify match phase transitions still fire correctly for non-CM formats (salary cap, draft, auction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)